### PR TITLE
Remove max-width from body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -266,7 +266,6 @@ body {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  max-width: 960px;
   margin: 0 auto;
   width: 100%;
   padding: 1.5rem;


### PR DESCRIPTION
Delete the fixed `max-width: 960px` on the body selector so the page can use the full available width. This makes the layout less constrained and improves responsiveness for wider viewports.