### PR TITLE
Make header responsive: mobile tags & CSS cleanup

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -3,6 +3,10 @@ name: Update Sitemap
 on:
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
+  workflow_run:
+    workflows: ["Deploy to GitHub Pages"]
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:

--- a/src/components/layout/DetailView.tsx
+++ b/src/components/layout/DetailView.tsx
@@ -206,7 +206,8 @@ export const DetailView = (props: DetailViewProps) => {
       <div class="detail-card">
         {/* Header */}
         <div class="dh">
-          <div class="dh-top">
+          {/* Mobile: tags + share above title */}
+          <div class="dh-top dh-top-mobile">
             <div class="dh-tags">
               <Show when={(rep().replications?.length || 0) > 0}>
                 <span class="dh-tag original">Original</span>
@@ -223,7 +224,25 @@ export const DetailView = (props: DetailViewProps) => {
               <LinkIcon />
             </button>
           </div>
-          <h1 class="dh-title">{rep().title || na("Title")}</h1>
+          {/* Desktop: title with tags + share inline */}
+          <div class="dh-title-row">
+            <h1 class="dh-title">{rep().title || na("Title")}</h1>
+            <div class="dh-title-actions">
+              <Show when={(rep().replications?.length || 0) > 0}>
+                <span class="dh-tag original">Original</span>
+              </Show>
+              <Show when={(rep().originals?.length || 0) > 0}>
+                <span class="dh-tag replication">Replication</span>
+              </Show>
+              <button
+                class="dh-share-btn"
+                onClick={handleShareLink}
+                title="Copy share link"
+              >
+                <LinkIcon />
+              </button>
+            </div>
+          </div>
           <div class="dh-authors">
             {renderAuthors(rep().authors)} ({rep().year || na("Year")})
           </div>
@@ -408,7 +427,6 @@ export const DetailView = (props: DetailViewProps) => {
             </Show>
           </div>
         </Show>
-
       </div>
 
       {/* Toast */}

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,17 @@
-@import url('https://fonts.googleapis.com/css2?family=Domine:wght@400;500;600;700&family=Source+Sans+3:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Domine:wght@400;500;600;700&family=Source+Sans+3:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap");
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
 @plugin "daisyui" {
   themes: light --default;
-};
+}
 
 :root {
   --primary: #853953;
-  --primary-dark: #612D53;
+  --primary-dark: #612d53;
   --primary-light: #a04d6b;
   --primary-faint: #f9f0f4;
-  --neutral: #2C2C2C;
-  --surface: #F3F4F4;
+  --neutral: #2c2c2c;
+  --surface: #f3f4f4;
   --surface-alt: #e8e9e9;
   --white: #fff;
   --success: #853953;
@@ -27,7 +27,7 @@
   --info: #853953;
   --info-bg: #f9f0f4;
   --info-border: #d4a5b8;
-  --text: #2C2C2C;
+  --text: #2c2c2c;
   --text-secondary: #4a4a4a;
   --text-muted: #888;
   --text-faint: #aaa;
@@ -49,7 +49,9 @@
   --color-white: var(--white);
 }
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -413,10 +415,18 @@ body {
   height: 6px;
   border-radius: 50%;
 }
-.filter-dot.all { background: var(--primary); }
-.filter-dot.success { background: var(--success); }
-.filter-dot.mixed { background: var(--warning); }
-.filter-dot.failed { background: var(--error); }
+.filter-dot.all {
+  background: var(--primary);
+}
+.filter-dot.success {
+  background: var(--success);
+}
+.filter-dot.mixed {
+  background: var(--warning);
+}
+.filter-dot.failed {
+  background: var(--error);
+}
 
 /* ─── Type filter bar ─── */
 .sli-filter-bar {
@@ -470,9 +480,16 @@ body {
   overflow-y: auto;
   padding: 0.4rem;
 }
-.study-list::-webkit-scrollbar { width: 5px; }
-.study-list::-webkit-scrollbar-track { background: transparent; }
-.study-list::-webkit-scrollbar-thumb { background: var(--border); border-radius: 100px; }
+.study-list::-webkit-scrollbar {
+  width: 5px;
+}
+.study-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+.study-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 100px;
+}
 
 .sli {
   display: flex;
@@ -486,7 +503,9 @@ body {
   margin-bottom: 1px;
   position: relative;
 }
-.sli:hover { background: var(--surface); }
+.sli:hover {
+  background: var(--surface);
+}
 .sli.active {
   background: var(--primary-faint);
   border-color: rgba(133, 57, 83, 0.1);
@@ -508,11 +527,23 @@ body {
   flex-shrink: 0;
   margin-top: 0.35rem;
 }
-.sli-dot.mixed, .sli-dot.partial { background: var(--warning); }
-.sli-dot.successful { background: #16a34a; }
-.sli-dot.failed { background: var(--error); }
-.sli-dot.blank { background: var(--text-muted); }
-.sli-body { flex: 1; min-width: 0; }
+.sli-dot.mixed,
+.sli-dot.partial {
+  background: var(--warning);
+}
+.sli-dot.successful {
+  background: #16a34a;
+}
+.sli-dot.failed {
+  background: var(--error);
+}
+.sli-dot.blank {
+  background: var(--text-muted);
+}
+.sli-body {
+  flex: 1;
+  min-width: 0;
+}
 .sli-title {
   font-weight: 600;
   font-size: 13px;
@@ -541,11 +572,26 @@ body {
   font-weight: 600;
   line-height: 1.4;
 }
-.sli-pill.s { background: #ecfdf5; color: #16a34a; }
-.sli-pill.m { background: var(--warning-bg); color: var(--warning); }
-.sli-pill.f { background: var(--error-bg); color: var(--error); }
-.sli-type-tag.original { background: #eff6ff; color: #2563eb; }
-.sli-type-tag.replication { background: #f5f3ff; color: #7c3aed; }
+.sli-pill.s {
+  background: #ecfdf5;
+  color: #16a34a;
+}
+.sli-pill.m {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+.sli-pill.f {
+  background: var(--error-bg);
+  color: var(--error);
+}
+.sli-type-tag.original {
+  background: #eff6ff;
+  color: #2563eb;
+}
+.sli-type-tag.replication {
+  background: #f5f3ff;
+  color: #7c3aed;
+}
 .sli-pills-sep {
   width: 1px;
   height: 12px;
@@ -562,9 +608,16 @@ body {
   display: flex;
   flex-direction: column;
 }
-.right-panel::-webkit-scrollbar { width: 6px; }
-.right-panel::-webkit-scrollbar-track { background: transparent; }
-.right-panel::-webkit-scrollbar-thumb { background: var(--border); border-radius: 100px; }
+.right-panel::-webkit-scrollbar {
+  width: 6px;
+}
+.right-panel::-webkit-scrollbar-track {
+  background: transparent;
+}
+.right-panel::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 100px;
+}
 
 /* ─── Scroll layout paper sections ─── */
 .scroll-paper-section {
@@ -691,8 +744,13 @@ body {
   color: var(--primary);
   background: var(--primary-faint);
 }
-.welcome-doi svg { opacity: 0.4; flex-shrink: 0; }
-.welcome-doi:hover svg { opacity: 0.8; }
+.welcome-doi svg {
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+.welcome-doi:hover svg {
+  opacity: 0.8;
+}
 
 /* ─── Detail content ─── */
 .detail-wrap {
@@ -708,8 +766,14 @@ body {
   animation: slideUp 0.3s ease-out;
 }
 @keyframes slideUp {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ─── Detail header ─── */
@@ -740,10 +804,30 @@ body {
   gap: 0.4rem;
   margin-bottom: 0.35rem;
 }
+/* Mobile-only tags row (hidden on desktop, shown at <=640px) */
+.dh-top.dh-top-mobile {
+  display: none;
+}
 .dh-tags {
   display: flex;
   align-items: center;
   gap: 0.35rem;
+}
+/* Desktop: title + tags inline */
+.dh-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+.dh-title-row .dh-title {
+  margin-bottom: 0.4rem;
+}
+.dh-title-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-shrink: 0;
 }
 .dh-share-btn {
   display: inline-flex;
@@ -875,7 +959,9 @@ body {
 .ab-btn.accent:hover {
   background: var(--primary-light);
 }
-.ab-btn svg { flex-shrink: 0; }
+.ab-btn svg {
+  flex-shrink: 0;
+}
 
 /* ─── Progress bar ─── */
 .progress-section {
@@ -908,9 +994,15 @@ body {
   border-radius: 100px;
   transition: width 0.5s ease;
 }
-.progress-seg.success { background: var(--success); }
-.progress-seg.mixed { background: var(--warning); }
-.progress-seg.failed { background: var(--error); }
+.progress-seg.success {
+  background: var(--success);
+}
+.progress-seg.mixed {
+  background: var(--warning);
+}
+.progress-seg.failed {
+  background: var(--error);
+}
 .progress-pct {
   font-size: 12px;
   font-weight: 600;
@@ -941,8 +1033,12 @@ body {
   transition: color var(--transition-fast);
   white-space: nowrap;
 }
-.tab-btn:hover { color: var(--text-secondary); }
-.tab-btn.active { color: var(--primary); }
+.tab-btn:hover {
+  color: var(--text-secondary);
+}
+.tab-btn.active {
+  color: var(--primary);
+}
 .tab-btn.active::after {
   content: "";
   position: absolute;
@@ -977,7 +1073,9 @@ body {
   transition: box-shadow var(--transition-fast);
   overflow: hidden;
 }
-.rep-item:hover { box-shadow: var(--shadow-sm); }
+.rep-item:hover {
+  box-shadow: var(--shadow-sm);
+}
 .rep-item-main {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -997,11 +1095,25 @@ body {
   min-width: 56px;
   text-align: center;
 }
-.ri-badge.successful { background: var(--success-bg); color: var(--success); }
-.ri-badge.failed { background: var(--error-bg); color: var(--error); }
-.ri-badge.mixed { background: var(--warning-bg); color: var(--warning); }
-.ri-badge.partial { background: var(--warning-bg); color: #9a6f00; }
-.ri-body { min-width: 0; }
+.ri-badge.successful {
+  background: var(--success-bg);
+  color: var(--success);
+}
+.ri-badge.failed {
+  background: var(--error-bg);
+  color: var(--error);
+}
+.ri-badge.mixed {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+.ri-badge.partial {
+  background: var(--warning-bg);
+  color: #9a6f00;
+}
+.ri-body {
+  min-width: 0;
+}
 .ri-title {
   font-weight: 600;
   font-size: 13.5px;
@@ -1020,7 +1132,9 @@ body {
   margin-top: 0.15rem;
   display: inline-block;
 }
-.ri-doi:hover { text-decoration: underline; }
+.ri-doi:hover {
+  text-decoration: underline;
+}
 .ri-actions {
   display: flex;
   gap: 0.3rem;
@@ -1048,7 +1162,9 @@ body {
   color: var(--primary);
   background: var(--primary-faint);
 }
-.ri-action svg { flex-shrink: 0; }
+.ri-action svg {
+  flex-shrink: 0;
+}
 
 /* Expandable quote */
 .ri-expand {
@@ -1071,7 +1187,9 @@ body {
   gap: 0.3rem;
   transition: color var(--transition-fast);
 }
-.ri-expand-toggle:hover { color: var(--primary-light); }
+.ri-expand-toggle:hover {
+  color: var(--primary-light);
+}
 .ri-expand-toggle .arrow {
   transition: transform var(--transition);
   font-size: 10px;
@@ -1146,13 +1264,17 @@ body {
   background: var(--primary);
   color: var(--white);
 }
-.cb-btn.primary:hover { background: var(--primary-light); }
+.cb-btn.primary:hover {
+  background: var(--primary-light);
+}
 .cb-btn.ghost {
   background: var(--white);
   color: var(--primary);
   border: 1px solid rgba(133, 57, 83, 0.15);
 }
-.cb-btn.ghost:hover { border-color: var(--primary); }
+.cb-btn.ghost:hover {
+  border-color: var(--primary);
+}
 
 /* ═══════════════════════════════
    FOOTER
@@ -1199,7 +1321,9 @@ body {
   animation: spin 0.8s linear infinite;
 }
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Empty left panel state */
@@ -1262,9 +1386,13 @@ body {
 /* ═══════════════════════════════
    RESPONSIVE
 ═══════════════════════════════ */
-@media (max-width: 960px) {
-  body { overflow: auto; }
-  #root { overflow: auto; }
+@media (max-width: 960px) and (orientation: landscape) {
+  body {
+    overflow: auto;
+  }
+  #root {
+    overflow: auto;
+  }
   .main-layout {
     grid-template-columns: 1fr;
     overflow: visible;
@@ -1274,23 +1402,45 @@ body {
     border-right: none;
     border-bottom: 1px solid var(--border-light);
   }
-  .right-panel { overflow: visible; }
-  .topbar-search-desktop {
+  .right-panel {
+    overflow: visible;
+  }
+  .topbar-search {
     max-width: 40vw;
     width: 340px;
   }
-  .topbar-search-desktop:focus-within { width: 340px; }
-  .contribute-bar { margin: 0.5rem 1.25rem 1.25rem; }
+  .topbar-search:focus-within {
+    width: 340px;
+  }
+  .contribute-bar {
+    margin: 0.5rem 1.25rem 1.25rem;
+  }
 }
-@media (max-width: 640px) {
-  .topbar { padding: 0 0.75rem; }
+
+/* ─── Tablet portrait: mobile-like continuous scroll ─── */
+@media (max-width: 960px) and (orientation: portrait) {
+  body {
+    overflow: auto;
+  }
+  #root {
+    overflow: auto;
+  }
+  .topbar {
+    padding: 0 0.75rem;
+  }
 
   /* Hide desktop search and nav, show hamburger + mobile search */
-  .topbar-search-desktop { display: none; }
-  .topbar-right-desktop { display: none; }
-  .topbar-hamburger { display: flex; }
+  .topbar-search-desktop {
+    display: none;
+  }
+  .topbar-right-desktop {
+    display: none;
+  }
+  .topbar-hamburger {
+    display: flex;
+  }
 
-  /* ─── Mobile search bar ─── */
+  /* Mobile search bar */
   .topbar-mobile-search {
     display: flex;
     flex-direction: column;
@@ -1299,7 +1449,6 @@ body {
     border-bottom: 1px solid var(--border-light);
     gap: 0.4rem;
   }
-  /* Mode toggle row */
   .mob-search-modes {
     display: flex;
     gap: 0.35rem;
@@ -1323,7 +1472,6 @@ body {
     border-color: rgba(133, 57, 83, 0.25);
     color: var(--primary);
   }
-  /* Input + button row */
   .mob-search-row {
     display: flex;
     align-items: center;
@@ -1331,7 +1479,9 @@ body {
     border: 1px solid var(--border-light);
     border-radius: var(--radius);
     padding-left: 0.6rem;
-    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+    transition:
+      border-color var(--transition-fast),
+      box-shadow var(--transition-fast);
   }
   .mob-search-row:focus-within {
     border-color: var(--primary);
@@ -1352,7 +1502,9 @@ body {
     overflow-y: hidden;
     scrollbar-width: none;
   }
-  .mob-search-input-wrap::-webkit-scrollbar { display: none; }
+  .mob-search-input-wrap::-webkit-scrollbar {
+    display: none;
+  }
   .mob-search-input-wrap input {
     flex: 1;
     min-width: 60px;
@@ -1410,7 +1562,7 @@ body {
     background: var(--primary-dark);
   }
 
-  /* ─── Mobile dropdown menu ─── */
+  /* Mobile dropdown menu */
   .topbar-mobile-menu {
     display: flex;
     flex-direction: column;
@@ -1445,7 +1597,7 @@ body {
     background: var(--primary-light);
   }
 
-  /* ─── Single-scroll mobile: hide left panel, flatten layout ─── */
+  /* Single-scroll: hide left panel, flatten layout */
   .left-panel {
     display: none;
   }
@@ -1464,38 +1616,65 @@ body {
   .scroll-paper-section {
     border-bottom: 8px solid var(--surface);
   }
-  .lp-filters { padding: 0.4rem 0.75rem; }
-  .detail-wrap { padding: 0.75rem; }
-  .dh { padding: 1.25rem; }
-  .dh-title { font-size: 1rem; }
-  .dh-authors { font-size: 13px; }
-  /* ─── Action bar mobile ─── */
+  .lp-filters {
+    padding: 0.4rem 0.75rem;
+  }
+  .detail-wrap {
+    padding: 0.75rem;
+  }
+  .dh {
+    padding: 1.25rem;
+  }
+
+  /* Tags: mobile layout */
+  .dh-top.dh-top-mobile {
+    display: flex;
+  }
+  .dh-title-actions {
+    display: none;
+  }
+  .dh-title-row {
+    display: block;
+  }
+
+  /* Action bar */
   .action-bar {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: 1fr 1fr;
     padding: 0.6rem 0.85rem;
     gap: 0.35rem;
   }
-  .ab-sep { display: none; }
+  .ab-sep {
+    display: none;
+  }
   .ab-group {
     display: contents;
   }
-  /* First group (View Paper + PDF): span full width */
   .ab-group:first-child .ab-btn {
-    grid-column: span 2;
     justify-content: center;
     min-height: 38px;
     font-size: 13px;
   }
-  /* Secondary buttons: 4 equal columns */
+  .ab-group:first-child .ab-btn:only-child {
+    grid-column: 1 / -1;
+  }
+  .ab-group:nth-child(3) {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-column: 1 / -1;
+    gap: 0.35rem;
+  }
   .ab-btn {
     font-size: 11px;
     padding: 0.35rem 0.3rem;
     min-height: 32px;
     justify-content: center;
   }
+  .ab-group:last-child .ab-btn {
+    grid-column: 1 / -1;
+  }
 
-  /* ─── Tabs bar mobile ─── */
+  /* Tabs */
   .tabs-bar {
     padding: 0;
     overflow: hidden;
@@ -1510,8 +1689,11 @@ body {
     font-size: 13px;
     min-height: 44px;
   }
-  .rep-list { padding: 0.75rem 1rem 1.25rem; }
-  /* Flatten rep-item for mobile reordering */
+  .rep-list {
+    padding: 0.75rem 1rem 1.25rem;
+  }
+
+  /* Rep items */
   .rep-item {
     display: flex;
     flex-direction: column;
@@ -1555,11 +1737,25 @@ body {
   .ri-action:active {
     background: var(--primary-faint);
   }
-  .ri-badge { min-width: auto; font-size: 9px; padding: 0.15rem 0.45rem; }
-  .progress-section { padding: 0.65rem 1rem; }
-  .progress-row { flex-wrap: wrap; gap: 0.5rem; }
-  .progress-label { width: 100%; }
-  .progress-pct { width: 100%; text-align: right; }
+  .ri-badge {
+    min-width: auto;
+    font-size: 9px;
+    padding: 0.15rem 0.45rem;
+  }
+  .progress-section {
+    padding: 0.65rem 1rem;
+  }
+  .progress-row {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .progress-label {
+    width: 100%;
+  }
+  .progress-pct {
+    width: 100%;
+    text-align: right;
+  }
   .contribute-bar {
     margin: 0.5rem 1rem 1.25rem;
     padding: 0.85rem 1rem;
@@ -1572,9 +1768,11 @@ body {
     text-align: center;
     padding: 0.65rem 1rem;
   }
-  .footer-bar a { margin-left: 0.5rem; }
+  .footer-bar a {
+    margin-left: 0.5rem;
+  }
 
-  /* ─── Welcome state mobile ─── */
+  /* Welcome state */
   .welcome-state {
     padding: 1.5rem 1.25rem;
   }
@@ -1600,17 +1798,56 @@ body {
     font-size: 13px;
   }
 }
+/* ─── Phone-specific size overrides ─── */
+@media (max-width: 640px) {
+  .dh-title {
+    font-size: 1rem;
+  }
+  .dh-authors {
+    font-size: 13px;
+  }
+}
 @media (max-width: 400px) {
-  .topbar-name span { display: none; }
-  .detail-wrap { padding: 0.35rem; }
-  .dh { padding: 0.85rem; }
-  .dh-title { font-size: 0.95rem; }
-  .dh-apa-text { font-size: 11.5px; }
-  .rep-list { padding: 0.5rem 0.75rem 1rem; }
-  .ri-title { font-size: 12.5px; }
-  .ri-meta { font-size: 11px; }
-  .contribute-bar { margin: 0.5rem 0.75rem 1rem; }
-  .footer-bar { font-size: 10.5px; }
+  .topbar-name span {
+    display: none;
+  }
+  .detail-wrap {
+    padding: 0.5rem;
+  }
+  .dh {
+    padding: 1rem;
+  }
+  .dh-title {
+    font-size: 0.95rem;
+  }
+  .dh-apa-text {
+    font-size: 11.5px;
+  }
+  .action-bar {
+    padding: 0.4rem 0.75rem;
+  }
+  .ab-sep {
+    display: none;
+  }
+  .rep-list {
+    padding: 0.5rem 0.75rem 1rem;
+  }
+  .ri-title {
+    font-size: 12.5px;
+  }
+  .ri-meta {
+    font-size: 11px;
+  }
+  .tab-btn {
+    font-size: 12px;
+    padding: 0.6rem 0.5rem;
+  }
+  .contribute-bar {
+    margin: 0.5rem 0.75rem 1rem;
+  }
+  .footer-bar {
+    font-size: 10.5px;
+  }
 }
 
 /* Academic reference styling */
@@ -1621,10 +1858,16 @@ body {
   font-size: small;
   font-style: italic;
 }
-.reference em { font-style: italic; }
-.reference strong { font-weight: bold; }
+.reference em {
+  font-style: italic;
+}
+.reference strong {
+  font-weight: bold;
+}
 
-.md-to-html { font-style: inherit; }
+.md-to-html {
+  font-style: inherit;
+}
 
 /* Not Available fallback text */
 .not-available {


### PR DESCRIPTION
Move tags and share button above the title on mobile and expose a desktop title row that includes inline tags and share actions in DetailView.tsx. Update index.css with styling to support the new .dh-top.dh-top-mobile, .dh-title-row, and .dh-title-actions layouts, refine responsive media queries (landscape/portrait handling), and tidy up selector/formatting (multi-line rules, scrollbar, and spacing adjustments). Also normalize import quoting and some color hex casing; numerous small visual and layout tweaks to improve mobile/tablet behavior and consistency.