### PR TITLE
Generate sitemap during deploy; simplify schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate sitemap
+        run: node scripts/generate-sitemap.js
+        env:
+          OUTPUT_PATH: public/sitemap.xml
+
       - name: Build
         run: npm run build:gh-pages
 

--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -3,10 +3,6 @@ name: Update Sitemap
 on:
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
-  workflow_run:
-    workflows: ["Deploy to GitHub Pages"]
-    types:
-      - completed
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add a 'Generate sitemap' step to .github/workflows/deploy.yml that runs node scripts/generate-sitemap.js with OUTPUT_PATH=public/sitemap.xml before the build step. Remove the workflow_run trigger from .github/workflows/update-sitemap.yml so it only runs on the scheduled cron and via workflow_dispatch, decoupling it from the Deploy to GitHub Pages workflow.