### PR TITLE
Decode DOI route parameter

### DIFF
--- a/src/components/pages/DoiPage.tsx
+++ b/src/components/pages/DoiPage.tsx
@@ -12,7 +12,7 @@ export const DoiPage = () => {
   const params = useParams<{ doi: string }>();
   const navigate = useNavigate();
 
-  const doi = () => params.doi;
+  const doi = () => decodeURIComponent(params.doi);
   const [paper, setPaper] = createSignal<OriginalPaper | null>(null);
   const [isLoading, setIsLoading] = createSignal(true);
   const [hasData, setHasData] = createSignal(false);


### PR DESCRIPTION
Use decodeURIComponent on the DOI route param before using it. This fixes issues where URL-encoded DOIs (e.g. containing %2F or other encoded characters) were not interpreted correctly, ensuring the app receives the original DOI string.