### PR TITLE
Avoid unwanted reset on programmatic URL updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ function App() {
   let isScrollingFromClick = false;
   let scrollClickTimer: number | undefined;
   let observer: IntersectionObserver | undefined;
+  let ignoreNextReset = false;
 
   const visibilityMap = new Map<string, number>();
 
@@ -129,7 +130,7 @@ function App() {
     setTags([]);
     setResults({});
     setSelectedDoi(null);
-    setHasSearched(false);
+    if (hasSearched()) ignoreNextReset = true;
     setSearchParams({ q: undefined, dois: undefined });
   };
 
@@ -192,11 +193,15 @@ function App() {
       doFuzzySearch(q);
     } else {
       // URL has no search params — reset to welcome state
-      setTags([]);
-      setInputValue("");
-      setResults({});
-      setSelectedDoi(null);
-      setHasSearched(false);
+      if (ignoreNextReset) {
+        ignoreNextReset = false;
+      } else {
+        setTags([]);
+        setInputValue("");
+        setResults({});
+        setSelectedDoi(null);
+        setHasSearched(false);
+      }
     }
   });
 
@@ -212,7 +217,7 @@ function App() {
           if (v.trim() === "" && searchMode() === "fuzzy" && tags().length === 0) {
             setResults({});
             setSelectedDoi(null);
-            setHasSearched(false);
+            ignoreNextReset = true;
             setSearchParams({ q: undefined, dois: undefined });
           }
         }}
@@ -250,6 +255,7 @@ function App() {
           <Show
             when={Object.keys(results()).length > 0}
             fallback={
+              <Show when={!hasSearched()}>
               <WelcomeState
                 tags={tags()}
                 inputValue={inputValue()}
@@ -275,6 +281,7 @@ function App() {
                   }
                 }}
               />
+              </Show>
             }
           >
             <For each={Object.entries(results())}>


### PR DESCRIPTION
Introduce an ignoreNextReset flag to prevent the app from clearing UI state when search params are updated programmatically. Set the flag instead of immediately clearing hasSearched in places that call setSearchParams, and skip the reset in the URL-observer when the flag is set. Also conditionally render the WelcomeState only when the user hasn't searched, avoiding flicker or unwanted welcome UI when results are intentionally empty.