### PR TITLE
Only clear DOI input when switching from DOI mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,8 +125,13 @@ function App() {
   };
 
   const handleSearchModeChange = (mode: SearchMode) => {
+    const currentMode = searchMode();
+    const currentInput = inputValue();
+    const looksLikeDoi = /10\.\d{4,}/.test(currentInput) || currentInput.includes("doi.org/");
     setSearchMode(mode);
-    setInputValue("");
+    if (currentMode === "doi" && looksLikeDoi) {
+      setInputValue("");
+    }
     setTags([]);
     setResults({});
     setSelectedDoi(null);


### PR DESCRIPTION
When changing the search mode, preserve the current input unless the previous mode was "doi" and the input looks like a DOI. Added a DOI detection check (regex for 10.<digits> and presence of "doi.org/") and only clear inputValue in that specific case, avoiding accidental clearing of non-DOI queries.