### PR TITLE
Show detailed outcome badges; update types & styles

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -33,7 +33,17 @@ export type ReplicationItem = {
   apa_ref: string;
   bibtex_ref: string;
   url: string | null;
-  outcome: "successful" | "failed" | "mixed" | "partial";
+  outcome: "successful" | "failed" | "mixed" | "partial"
+    | "computationally successful, robust"
+    | "computationally successful, robustness challenges"
+    | "computationally successful, robustness not checked"
+    | "computational issues, robust"
+    | "computational issues, robustness challenges"
+    | "computational issues, robustness not checked"
+    | "computation not checked, robust"
+    | "computation not checked, robustness challenges"
+    | "computation not checked, robustness not checked"
+    | string;
   outcome_quote?: string;
   outcome_quote_source?: string;
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,10 +132,10 @@ function App() {
     setTags(newTags);
     syncUrl(newTags);
     if (newTags.length === 0) {
+      debouncedDoiSearch.cancel();
       setResults({});
       setSelectedDoi(null);
       setHasSearched(false);
-      setSearchParams({ dois: undefined, q: undefined });
     } else {
       debouncedDoiSearch(newTags);
     }

--- a/src/components/layout/DetailView.tsx
+++ b/src/components/layout/DetailView.tsx
@@ -130,7 +130,8 @@ export const DetailView = (props: DetailViewProps) => {
     if (!hasRepOrRepro && hasOriginals) {
       setActiveTab("originals");
     } else if (hasRepOrRepro) {
-      setActiveTab("replications");
+      const hasReplications = (r.replications?.length || 0) > 0;
+      setActiveTab(hasReplications ? "replications" : "reproductions");
     }
   });
 

--- a/src/components/layout/ReplicationItemCard.tsx
+++ b/src/components/layout/ReplicationItemCard.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createSignal, For } from "solid-js";
 import type { ReplicationItem } from "../../@types";
 import { renderAuthors, na } from "../../utils/formatter";
 
@@ -7,6 +7,37 @@ type ReplicationItemCardProps = {
   onCopyApa: (text: string) => void;
   onCopyBibtex: (text: string) => void;
 };
+
+type BadgeConfig = { label: string; cls: string };
+
+function parseOutcomeBadges(outcome: string): BadgeConfig[] {
+  const compMap: Record<string, BadgeConfig> = {
+    "computationally successful": { label: "Comp. Success", cls: "comp-success" },
+    "computational issues": { label: "Comp. Issues", cls: "comp-issues" },
+    "computation not checked": { label: "Comp. Not Checked", cls: "comp-unchecked" },
+  };
+  const robMap: Record<string, BadgeConfig> = {
+    "robust": { label: "Robust", cls: "robust" },
+    "robustness challenges": { label: "Rob. Challenges", cls: "rob-challenges" },
+    "robustness not checked": { label: "Not Checked", cls: "rob-unchecked" },
+  };
+
+  const lower = outcome?.toLowerCase() ?? "";
+  for (const [compKey, compBadge] of Object.entries(compMap)) {
+    for (const [robKey, robBadge] of Object.entries(robMap)) {
+      if (lower === `${compKey}, ${robKey}`) return [compBadge, robBadge];
+    }
+  }
+
+  // Fallback for standard outcomes
+  const simple: Record<string, BadgeConfig> = {
+    successful: { label: "Success", cls: "successful" },
+    failed: { label: "Failed", cls: "failed" },
+    mixed: { label: "Mixed", cls: "mixed" },
+    partial: { label: "Partial", cls: "partial" },
+  };
+  return [simple[lower] ?? { label: outcome || "N/A", cls: "" }];
+}
 
 const CopyIcon = () => (
   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -25,21 +56,16 @@ const ExternalLinkIcon = () => (
 
 export const ReplicationItemCard = (props: ReplicationItemCardProps) => {
   const [expanded, setExpanded] = createSignal(false);
-
-  const badgeLabel = () => {
-    switch (props.item.outcome) {
-      case "successful": return "Success";
-      case "failed": return "Failed";
-      case "mixed": return "Mixed";
-      case "partial": return "Partial";
-      default: return props.item.outcome || "N/A";
-    }
-  };
+  const badges = () => parseOutcomeBadges(props.item.outcome);
 
   return (
     <div class="rep-item">
       <div class="rep-item-main">
-        <span class={`ri-badge ${props.item.outcome || ""}`}>{badgeLabel()}</span>
+        <div class="ri-badge-group">
+          <For each={badges()}>
+            {(b) => <span class={`ri-badge ${b.cls}`}>{b.label}</span>}
+          </For>
+        </div>
         <div class="ri-body">
           <div class="ri-title">{props.item.title || na("Title")}</div>
           <div class="ri-meta">

--- a/src/index.css
+++ b/src/index.css
@@ -941,6 +941,18 @@ body {
   background: #f5f3ff;
   color: #7c3aed;
 }
+.dh-tag.rob-unchecked {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+.dh-tag.rob-challenges {
+  background: #fff7ed;
+  color: #c2410c;
+}
+.dh-tag.comp-unchecked {
+  background: #f3f4f6;
+  color: #6b7280;
+}
 .dh-authors {
   font-size: 14px;
   color: var(--text-secondary);
@@ -1189,6 +1201,35 @@ body {
 .ri-badge.partial {
   background: var(--warning-bg);
   color: #9a6f00;
+}
+.ri-badge-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.ri-badge.comp-success {
+  background: var(--success-bg);
+  color: var(--success);
+}
+.ri-badge.comp-issues {
+  background: var(--error-bg);
+  color: var(--error);
+}
+.ri-badge.comp-unchecked {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+.ri-badge.robust {
+  background: #f0fdf4;
+  color: #15803d;
+}
+.ri-badge.rob-challenges {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+.ri-badge.rob-unchecked {
+  background: #f4f4f4;
+  color: #888;
 }
 .ri-body {
   min-width: 0;


### PR DESCRIPTION
Expand ReplicationItem.outcome to include fine-grained computational/robustness variants and string fallback. Add parseOutcomeBadges and render one-or-two compact badges in ReplicationItemCard (imports For), replacing the single badge label. Add CSS for new badge classes and tag styles. Minor UI/behavior tweaks: cancel debounced DOI search when tags are cleared (App.tsx) and choose "reproductions" tab when there are no replications but reproductions exist (DetailView.tsx).