### PR TITLE
Changed the reproductions tags layout from column to row

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1204,7 +1204,8 @@ body {
 }
 .ri-badge-group {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: 0.3rem;
 }
 .ri-badge.comp-success {


### PR DESCRIPTION
Changed the tags layout from column to row and add flex-wrap: wrap so badges lay out horizontally and wrap onto multiple lines as needed, improving horizontal layout and responsiveness.