### PR TITLE
Auto-focus TopBar search input

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
 
   const paperRefs: Record<string, HTMLDivElement> = {};
   let rightPanelRef: HTMLDivElement | undefined;
+  let topbarInputRef: HTMLInputElement | undefined;
   let isScrollingFromClick = false;
   let scrollClickTimer: number | undefined;
   let observer: IntersectionObserver | undefined;
@@ -267,6 +268,12 @@ function App() {
     }
   });
 
+  createEffect(() => {
+    if (hasSearched()) {
+      setTimeout(() => topbarInputRef?.focus(), 0);
+    }
+  });
+
   return (
     <>
       <TopBar
@@ -274,6 +281,7 @@ function App() {
         inputValue={inputValue()}
         searchMode={searchMode()}
         showSearch={hasSearched()}
+        onInputRef={(el) => (topbarInputRef = el)}
         onInputChange={(v) => {
           setInputValue(v);
           if (searchMode() === "fuzzy") {

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -16,6 +16,7 @@ type TopBarProps = {
   onSearchSubmit: () => void;
   onNavigateSearch?: (tags: string[]) => void;
   onSearchModeChange: (mode: SearchMode) => void;
+  onInputRef?: (el: HTMLInputElement) => void;
 };
 
 export const TopBar = (props: TopBarProps) => {
@@ -181,7 +182,7 @@ export const TopBar = (props: TopBarProps) => {
             class="topbar-search topbar-search-desktop"
             onClick={() => inputRef?.focus()}
           >
-            {searchBar((el) => (inputRef = el))}
+            {searchBar((el) => { inputRef = el; props.onInputRef?.(el); })}
           </div>
         </Show>
         <div class="topbar-right topbar-right-desktop">


### PR DESCRIPTION
Add support for focusing the TopBar search input when a search is active. App.tsx introduces topbarInputRef, a createEffect that focuses the input when hasSearched() becomes true (using a zero-delay setTimeout to run after render), and passes an onInputRef callback to TopBar. TopBar.tsx accepts onInputRef in its props and invokes it when assigning the internal inputRef so the parent can control focus.