### PR TITLE
Render paper types as tags and support URL links

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -68,6 +68,7 @@ export type OriginalPaper = {
   apa_ref: string;
   bibtex_ref: string;
   url: string | null;
+  types?: string[];
   record: RecordData;
 };
 

--- a/src/components/layout/DetailView.tsx
+++ b/src/components/layout/DetailView.tsx
@@ -210,12 +210,13 @@ export const DetailView = (props: DetailViewProps) => {
           {/* Mobile: tags + share above title */}
           <div class="dh-top dh-top-mobile">
             <div class="dh-tags">
-              <Show when={(rep().replications?.length || 0) > 0}>
-                <span class="dh-tag original">Original</span>
-              </Show>
-              {/* <Show when={(rep().originals?.length || 0) > 0}>
-                <span class="dh-tag replication">Replication</span>
-              </Show> */}
+              <For each={props.paper.types || []}>
+                {(type) => (
+                  <span class={`dh-tag ${type.toLowerCase()}`}>
+                    {type.charAt(0).toUpperCase() + type.slice(1)}
+                  </span>
+                )}
+              </For>
             </div>
             <button
               class="dh-share-btn"
@@ -229,12 +230,13 @@ export const DetailView = (props: DetailViewProps) => {
           <div class="dh-title-row">
             <h1 class="dh-title">{rep().title || na("Title")}</h1>
             <div class="dh-title-actions">
-              <Show when={(rep().replications?.length || 0) > 0}>
-                <span class="dh-tag original">Original</span>
-              </Show>
-              {/* <Show when={(rep().originals?.length || 0) > 0}>
-                <span class="dh-tag replication">Replication</span>
-              </Show> */}
+              <For each={props.paper.types || []}>
+                {(type) => (
+                  <span class={`dh-tag ${type.toLowerCase()}`}>
+                    {type.charAt(0).toUpperCase() + type.slice(1)}
+                  </span>
+                )}
+              </For>
               <button
                 class="dh-share-btn"
                 onClick={handleShareLink}

--- a/src/components/layout/ReplicationItemCard.tsx
+++ b/src/components/layout/ReplicationItemCard.tsx
@@ -72,7 +72,7 @@ export const ReplicationItemCard = (props: ReplicationItemCardProps) => {
             {renderAuthors(props.item.authors)} ({props.item.year || na("Year")}) &middot;{" "}
             {props.item.journal || na("Journal")}
           </div>
-          {props.item.doi && (
+          {props.item.doi ? (
             <a
               class="ri-doi"
               href={`https://doi.org/${props.item.doi}`}
@@ -81,7 +81,16 @@ export const ReplicationItemCard = (props: ReplicationItemCardProps) => {
             >
               {props.item.doi}
             </a>
-          )}
+          ) : props.item.url ? (
+            <a
+              class="ri-doi"
+              href={props.item.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {props.item.url}
+            </a>
+          ) : null}
         </div>
         <div class="ri-actions">
           {props.item.apa_ref && (
@@ -102,10 +111,10 @@ export const ReplicationItemCard = (props: ReplicationItemCardProps) => {
               <CopyIcon /> BibTeX
             </button>
           )}
-          {props.item.doi && (
+          {(props.item.doi || props.item.url) && (
             <a
               class="ri-action"
-              href={`https://doi.org/${props.item.doi}`}
+              href={props.item.doi ? `https://doi.org/${props.item.doi}` : props.item.url!}
               target="_blank"
               rel="noreferrer"
               title="View paper"

--- a/src/components/layout/StudyListPanel.tsx
+++ b/src/components/layout/StudyListPanel.tsx
@@ -115,11 +115,9 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
 
     const cards = visible
       .map((entry) => {
-        const tags: string[] = [];
-        if (entry.isOriginal)
-          tags.push('<span class="tag original">Original</span>');
-        if (entry.isReplication)
-          tags.push('<span class="tag replication">Replication</span>');
+        const tags = (entry.paper.types || []).map(
+          (type) => `<span class="tag ${type.toLowerCase()}">${esc(type.charAt(0).toUpperCase() + type.slice(1))}</span>`
+        );
 
         const reps = entry.rep.replications || [];
         const origs = entry.rep.originals || [];
@@ -344,18 +342,16 @@ footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #ddd; font
                     {entry.rep.year || na("Year")}
                   </div>
                   <div class="sli-pills">
-                    <Show when={(entry.rep.replications?.length || 0) > 0}>
-                      <span class="sli-pill sli-type-tag original">
-                        Original
-                      </span>
-                    </Show>
-                    {/* <Show when={(entry.rep.originals?.length || 0) > 0}>
-                      <span class="sli-pill sli-type-tag replication">Replication</span>
-                    </Show> */}
+                    <For each={entry.paper.types || []}>
+                      {(type) => (
+                        <span class={`sli-pill sli-type-tag ${type.toLowerCase()}`}>
+                          {type.charAt(0).toUpperCase() + type.slice(1)}
+                        </span>
+                      )}
+                    </For>
                     <Show
                       when={
-                        ((entry.rep.replications?.length || 0) > 0 ||
-                          (entry.rep.originals?.length || 0) > 0) &&
+                        (entry.paper.types?.length || 0) > 0 &&
                         (entry.rep.outcomes?.total || 0) > 0
                       }
                     >


### PR DESCRIPTION
Add optional types field to OriginalPaper and render those types as UI tags across DetailView and StudyListPanel instead of hardcoded original/replication badges. In StudyListPanel the tag HTML is now built from entry.paper.types with escaping, and the visibility check was adjusted to require paper.types length when showing outcome-related UI. ReplicationItemCard now falls back to displaying the paper URL when DOI is absent and uses DOI or URL for the external "view paper" link. Files changed: src/@types/index.d.ts, DetailView.tsx, ReplicationItemCard.tsx, StudyListPanel.tsx.