### PR TITLE
Add DOI paste parser and alert dialog

### DIFF
--- a/src/components/layout/AlertDialog.tsx
+++ b/src/components/layout/AlertDialog.tsx
@@ -1,0 +1,100 @@
+import { Show, onCleanup, onMount, type JSX } from "solid-js";
+
+type AlertDialogProps = {
+  open: boolean;
+  title?: string;
+  message: string;
+  hint?: JSX.Element;
+  confirmLabel?: string;
+  variant?: "warning" | "error" | "info";
+  onClose: () => void;
+};
+
+export const AlertDialog = (props: AlertDialogProps) => {
+  const handleKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape" && props.open) props.onClose();
+  };
+
+  onMount(() => window.addEventListener("keydown", handleKey));
+  onCleanup(() => window.removeEventListener("keydown", handleKey));
+
+  return (
+    <Show when={props.open}>
+      <div
+        class="alert-dialog-backdrop"
+        onClick={props.onClose}
+        role="presentation"
+      >
+        <div
+          class="alert-dialog"
+          classList={{
+            "alert-dialog-warning": (props.variant ?? "warning") === "warning",
+            "alert-dialog-error": props.variant === "error",
+            "alert-dialog-info": props.variant === "info",
+          }}
+          onClick={(e) => e.stopPropagation()}
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="alert-dialog-title"
+        >
+          <button
+            type="button"
+            class="alert-dialog-close"
+            aria-label="Close"
+            onClick={props.onClose}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
+          <div class="alert-dialog-icon" aria-hidden="true">
+            <svg
+              width="26"
+              height="26"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </div>
+
+          <h3 class="alert-dialog-title" id="alert-dialog-title">
+            {props.title ?? "Heads up"}
+          </h3>
+          <p class="alert-dialog-message">{props.message}</p>
+          <Show when={props.hint}>
+            <div class="alert-dialog-hint">{props.hint}</div>
+          </Show>
+
+          <div class="alert-dialog-actions">
+            <button
+              type="button"
+              class="alert-dialog-confirm"
+              onClick={props.onClose}
+              autofocus
+            >
+              {props.confirmLabel ?? "Got it"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,6 +1,8 @@
 import { createSignal, For, Show } from "solid-js";
 import { A } from "@solidjs/router";
 import forrt from "../../assets/FORRT.svg";
+import { parseDoiPaste } from "../../utils/doi";
+import { AlertDialog } from "./AlertDialog";
 
 export type SearchMode = "doi" | "fuzzy";
 
@@ -19,21 +21,13 @@ type TopBarProps = {
   onInputRef?: (el: HTMLInputElement) => void;
 };
 
-// DOIs never contain whitespace, commas, or semicolons, so any of these
-// (plus newlines/tabs) safely delimit one DOI from the next.
-const DOI_DELIMITER_RE = /[\s,;]+/;
 const DOI_DELIMITER_KEYS = new Set([",", ";", " ", "Tab"]);
-
-const splitDoiInput = (raw: string) =>
-  raw
-    .split(DOI_DELIMITER_RE)
-    .map((s) => s.trim())
-    .filter((s) => s !== "");
 
 export const TopBar = (props: TopBarProps) => {
   let inputRef: HTMLInputElement | undefined;
   let mobileInputRef: HTMLInputElement | undefined;
   const [menuOpen, setMenuOpen] = createSignal(false);
+  const [alertMessage, setAlertMessage] = createSignal<string | null>(null);
 
   const fireSearch = (extraTag?: string) => {
     const allTags = extraTag ? [...props.tags, extraTag] : [...props.tags];
@@ -76,14 +70,18 @@ export const TopBar = (props: TopBarProps) => {
   const handlePaste = (e: ClipboardEvent) => {
     if (props.searchMode !== "doi") return;
     const pasted = e.clipboardData?.getData("text") || "";
-    if (!DOI_DELIMITER_RE.test(pasted)) return;
+    const result = parseDoiPaste(pasted);
+    if (result.kind === "none") return;
     e.preventDefault();
-    const parts = splitDoiInput(pasted);
-    if (parts.length === 0) return;
+    if (result.kind === "reject") {
+      setAlertMessage(result.reason);
+      return;
+    }
+    const toAdd = result.kind === "single" ? [result.doi] : result.dois;
     if (props.onAddTags) {
-      props.onAddTags(parts);
+      props.onAddTags(toAdd);
     } else {
-      for (const part of parts) {
+      for (const part of toAdd) {
         props.onAddTag(part);
       }
     }
@@ -372,6 +370,21 @@ export const TopBar = (props: TopBarProps) => {
           </a>
         </div>
       )}
+
+      <AlertDialog
+        open={alertMessage() !== null}
+        title="Can't split that paste"
+        message={alertMessage() ?? ""}
+        variant="warning"
+        hint={
+          <>
+            Try separating DOIs with a comma, semicolon, or newline — e.g.
+            {" "}
+            <code>10.1371/journal.pone.0335330, 10.1075/target.18159.ola</code>
+          </>
+        }
+        onClose={() => setAlertMessage(null)}
+      />
     </div>
   );
 };

--- a/src/components/layout/WelcomeState.tsx
+++ b/src/components/layout/WelcomeState.tsx
@@ -1,14 +1,9 @@
-import { For } from "solid-js";
+import { createSignal, For } from "solid-js";
 import type { SearchMode } from "./TopBar";
+import { parseDoiPaste } from "../../utils/doi";
+import { AlertDialog } from "./AlertDialog";
 
-const DOI_DELIMITER_RE = /[\s,;]+/;
 const DOI_DELIMITER_KEYS = new Set([",", ";", " ", "Tab"]);
-
-const splitDoiInput = (raw: string) =>
-  raw
-    .split(DOI_DELIMITER_RE)
-    .map((s) => s.trim())
-    .filter((s) => s !== "");
 
 type WelcomeStateProps = {
   tags: string[];
@@ -34,6 +29,7 @@ export const exampleSearches = [
 
 export const WelcomeState = (props: WelcomeStateProps) => {
   let inputRef: HTMLInputElement | undefined;
+  const [alertMessage, setAlertMessage] = createSignal<string | null>(null);
 
   const fireSearch = (extraTag?: string) => {
     const allTags = extraTag ? [...props.tags, extraTag] : [...props.tags];
@@ -76,14 +72,18 @@ export const WelcomeState = (props: WelcomeStateProps) => {
   const handlePaste = (e: ClipboardEvent) => {
     if (props.searchMode !== "doi") return;
     const pasted = e.clipboardData?.getData("text") || "";
-    if (!DOI_DELIMITER_RE.test(pasted)) return;
+    const result = parseDoiPaste(pasted);
+    if (result.kind === "none") return;
     e.preventDefault();
-    const parts = splitDoiInput(pasted);
-    if (parts.length === 0) return;
+    if (result.kind === "reject") {
+      setAlertMessage(result.reason);
+      return;
+    }
+    const toAdd = result.kind === "single" ? [result.doi] : result.dois;
     if (props.onAddTags) {
-      props.onAddTags(parts);
+      props.onAddTags(toAdd);
     } else {
-      for (const part of parts) {
+      for (const part of toAdd) {
         props.onAddTag(part);
       }
     }
@@ -220,6 +220,21 @@ export const WelcomeState = (props: WelcomeStateProps) => {
         (FLoRA), the Replication Atlas covers 1,600+ original findings paired
         with replication outcomes across research disciplines.
       </p>
+
+      <AlertDialog
+        open={alertMessage() !== null}
+        title="Can't split that paste"
+        message={alertMessage() ?? ""}
+        variant="warning"
+        hint={
+          <>
+            Try separating DOIs with a comma, semicolon, or newline — e.g.
+            {" "}
+            <code>10.1371/journal.pone.0335330, 10.1075/target.18159.ola</code>
+          </>
+        }
+        onClose={() => setAlertMessage(null)}
+      />
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1542,6 +1542,168 @@ body {
   animation: slideUp 0.2s ease-out;
 }
 
+/* Alert dialog */
+.alert-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.5);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1100;
+  animation: alertFadeIn 0.18s ease-out;
+}
+
+.alert-dialog {
+  position: relative;
+  background: var(--white);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 12px 36px rgba(17, 24, 39, 0.18);
+  max-width: 420px;
+  width: 100%;
+  padding: 1.75rem 1.5rem 1.25rem;
+  text-align: center;
+  font-family: var(--font-body);
+  animation: alertPopIn 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.alert-dialog-close {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.alert-dialog-close:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text);
+}
+
+.alert-dialog-close:focus-visible {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
+.alert-dialog-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+  background: var(--warning-bg);
+  color: var(--warning);
+  box-shadow: 0 0 0 6px rgba(184, 134, 11, 0.08);
+}
+
+.alert-dialog-error .alert-dialog-icon {
+  background: var(--error-bg);
+  color: var(--error);
+  box-shadow: 0 0 0 6px rgba(180, 35, 24, 0.08);
+}
+
+.alert-dialog-info .alert-dialog-icon {
+  background: var(--primary-faint);
+  color: var(--primary);
+  box-shadow: 0 0 0 6px rgba(133, 57, 83, 0.08);
+}
+
+.alert-dialog-title {
+  margin: 0 0 0.4rem;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.alert-dialog-message {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.alert-dialog-hint {
+  margin-top: 0.85rem;
+  padding: 0.65rem 0.85rem;
+  background: var(--primary-faint);
+  border-radius: 8px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text);
+  text-align: left;
+}
+
+.alert-dialog-hint code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  background: var(--white);
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  border: 1px solid var(--primary-faint);
+  color: var(--primary-dark);
+}
+
+.alert-dialog-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.25rem;
+}
+
+.alert-dialog-confirm {
+  background: var(--primary);
+  color: var(--white);
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.4rem;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+  min-width: 110px;
+}
+
+.alert-dialog-confirm:hover {
+  background: var(--primary-dark);
+}
+
+.alert-dialog-confirm:active {
+  transform: scale(0.98);
+}
+
+.alert-dialog-confirm:focus-visible {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 2px;
+}
+
+@keyframes alertFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes alertPopIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.96); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 /* ═══════════════════════════════
    TOPBAR WRAPPER & MOBILE ELEMENTS
 ═══════════════════════════════ */

--- a/src/utils/doi.ts
+++ b/src/utils/doi.ts
@@ -1,0 +1,41 @@
+// Anything that separates DOIs in a pasted citation list: commas, semicolons,
+// and any whitespace (spaces, tabs, newlines).
+const DOI_DELIMITER_RE = /[\s,;]+/;
+const DOI_PREFIX_RE = /10\./g;
+
+export type DoiPasteResult =
+  | { kind: "none" }
+  | { kind: "single"; doi: string }
+  | { kind: "multi"; dois: string[] }
+  | { kind: "reject"; reason: string };
+
+export const MULTI_DOI_WHITESPACE_REJECTION =
+  "If you copy in multiple DOIs at once, they must not contain any spaces or other whitespace within them.";
+
+export function parseDoiPaste(raw: string): DoiPasteResult {
+  // No delimiters → not a multi-DOI paste; let normal paste behavior run.
+  if (!DOI_DELIMITER_RE.test(raw)) return { kind: "none" };
+
+  const prefixCount = (raw.match(DOI_PREFIX_RE) || []).length;
+
+  // Zero or one "10." in the pasted text: assume any whitespace is accidental
+  // (line wrap, trailing newline, copy-paste artifact) and collapse it.
+  if (prefixCount <= 1) {
+    const collapsed = raw.replace(/[\s,;]+/g, "").trim();
+    if (!collapsed) return { kind: "none" };
+    return { kind: "single", doi: collapsed };
+  }
+
+  // Multiple "10." occurrences: each delimiter-separated chunk must itself be
+  // a DOI. If any chunk doesn't start with "10.", the user pasted DOIs that
+  // contain internal whitespace and we can't safely guess where the breaks are.
+  const parts = raw
+    .split(DOI_DELIMITER_RE)
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+  const allValid = parts.every((p) => p.startsWith("10."));
+  if (!allValid) {
+    return { kind: "reject", reason: MULTI_DOI_WHITESPACE_REJECTION };
+  }
+  return { kind: "multi", dois: parts };
+}


### PR DESCRIPTION
Introduce a reusable DOI paste parser and user-facing alert to handle pasted DOI lists more robustly. New src/utils/doi.ts centralizes parsing logic (parseDoiPaste) and returns structured results (none/single/multi/reject) with a clear rejection reason for DOIs that contain internal whitespace. Add a lightweight AlertDialog component (src/components/layout/AlertDialog.tsx) and corresponding styles in index.css to surface warnings. Integrate parsing and alerts into TopBar and WelcomeState to replace ad-hoc splitting logic and improve paste behaviour when adding tags/DOIs.