### PR TITLE
Add search outcomes banner and aggregate metrics

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -69,7 +69,7 @@ export type OriginalPaper = {
   bibtex_ref: string;
   url: string | null;
   types?: string[];
-  record: RecordData;
+  record: RecordData | null;
 };
 
 export type DOIResults = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
-import { createSignal, createEffect, Show, For, onCleanup } from "solid-js";
+import { createSignal, createEffect, createMemo, Show, For, onCleanup } from "solid-js";
 import { useSearchParams } from "@solidjs/router";
 import type { DOIResults, OriginalPaper } from "./@types";
 import { fetchMultipleDOIInfo, fetchFuzzySearch } from "./api/backend";
+import { formatReplicationResponse } from "./api/formatter";
+import { SearchOutcomesBanner } from "./components/replication/SearchOutcomesBanner";
 import { TopBar, type SearchMode } from "./components/layout/TopBar";
 import { StudyListPanel } from "./components/layout/StudyListPanel";
 import {
@@ -41,6 +43,27 @@ function App() {
   const [isLoading, setIsLoading] = createSignal(false);
   const [hasSearched, setHasSearched] = createSignal(false);
   const [hasEverSearched, setHasEverSearched] = createSignal(false);
+
+  const aggregateOutcomes = createMemo(() => {
+    const res = results();
+    const counts = Object.values(res).reduce(
+      (acc, paper) => {
+        const rep = formatReplicationResponse(paper);
+        acc.success += rep.outcomes?.success ?? 0;
+        acc.failed  += rep.outcomes?.failed  ?? 0;
+        acc.mixed   += rep.outcomes?.mixed   ?? 0;
+        acc.partial += rep.outcomes?.partial ?? 0;
+        acc.total   += rep.outcomes?.total   ?? 0;
+        return acc;
+      },
+      { success: 0, failed: 0, mixed: 0, partial: 0, total: 0 }
+    );
+    return { ...counts, categorizedTotal: counts.success + counts.failed + counts.mixed + counts.partial };
+  });
+
+  const paperCount = createMemo(() =>
+    Object.values(results()).filter(p => p.record != null).length
+  );
 
   const paperRefs: Record<string, HTMLDivElement> = {};
   let rightPanelRef: HTMLDivElement | undefined;
@@ -468,7 +491,13 @@ function App() {
               </Show>
             }
           >
-            <For each={Object.entries(results())}>
+            <>
+              <Show when={aggregateOutcomes().total > 0}>
+                <div class="p-4 pb-0">
+                  <SearchOutcomesBanner outcomes={aggregateOutcomes()} paperCount={paperCount()} />
+                </div>
+              </Show>
+              <For each={Object.entries(results())}>
               {([doi, paper]) => (
                 <div
                   data-doi={doi}
@@ -487,6 +516,7 @@ function App() {
                 </div>
               )}
             </For>
+            </>
           </Show>
         </div>
       </div>

--- a/src/components/replication/ReplicationSearchPanel.tsx
+++ b/src/components/replication/ReplicationSearchPanel.tsx
@@ -1,8 +1,10 @@
-import { createEffect, createSignal, Show  } from "solid-js";
+import { createEffect, createMemo, createSignal, Show } from "solid-js";
 import { Search } from "../Search";
 import { fetchMultipleDOIInfo } from "../../api/backend";
+import { formatReplicationResponse } from "../../api/formatter";
 import type { DOIResults } from "../../@types";
 import { ReplicationSummary } from "./ReplicationSummary";
+import { SearchOutcomesBanner } from "./SearchOutcomesBanner";
 import { Skeleton } from "../Skeleton";
 import { query } from "../../utils/http";
 import { ResearchNotFound } from "./ResearchNotFount";
@@ -10,13 +12,39 @@ import { ResearchNotFound } from "./ResearchNotFount";
 type ReplicationSearchPanelProps = {
     onSuccess?: (data: DOIResults) => void;
 };
+
 export const ReplicationSearchPanel = (props: ReplicationSearchPanelProps) => {
     const [searchTerm, setSearch] = createSignal(query.get('doi') || query.get('dois') || '');
     const [dois, setDois] = createSignal<DOIResults | null>(null);
     const [isLoading, setIsLoading] = createSignal(false);
     const [emptyResults, setEmptyResults] = createSignal(false);
     const resultEntries = () => Object.entries(dois()?.results || {});
-    
+
+    const aggregateOutcomes = createMemo(() => {
+        const results = dois()?.results;
+        if (!results) return { success: 0, failed: 0, mixed: 0, partial: 0, total: 0, categorizedTotal: 0 };
+        const counts = Object.values(results).reduce(
+            (acc, paper) => {
+                const rep = formatReplicationResponse(paper);
+                acc.success += rep.outcomes?.success ?? 0;
+                acc.failed  += rep.outcomes?.failed  ?? 0;
+                acc.mixed   += rep.outcomes?.mixed   ?? 0;
+                acc.partial += rep.outcomes?.partial ?? 0;
+                acc.total   += rep.outcomes?.total   ?? 0;
+                return acc;
+            },
+            { success: 0, failed: 0, mixed: 0, partial: 0, total: 0 }
+        );
+        return {
+            ...counts,
+            categorizedTotal: counts.success + counts.failed + counts.mixed + counts.partial,
+        };
+    });
+
+    const paperCount = createMemo(() =>
+        Object.values(dois()?.results || {}).filter(p => p.record != null).length
+    );
+
     createEffect(() => {
         const q = searchTerm();
         if (q.trim() === '') {
@@ -29,8 +57,7 @@ export const ReplicationSearchPanel = (props: ReplicationSearchPanelProps) => {
         setDois(null);
 
         const params = q.split(',').map(doi => doi.trim()).filter(doi => doi !== '');
-        
-        // Debounce the API call by 1 second
+
         const timeoutId = setTimeout(() => {
             setEmptyResults(false);
             fetchMultipleDOIInfo(params)
@@ -51,9 +78,9 @@ export const ReplicationSearchPanel = (props: ReplicationSearchPanelProps) => {
                 });
         }, 300);
 
-        // Cleanup function to clear timeout if searchTerm changes before timeout completes
         return () => clearTimeout(timeoutId);
     });
+
     return (
         <div class="p-4">
             <h2 class="text-lg font-bold mb-2">Search for Replications</h2>
@@ -64,6 +91,9 @@ export const ReplicationSearchPanel = (props: ReplicationSearchPanelProps) => {
                 </section>
             </Show>
             <Show when={dois() !== null && !isLoading()}>
+                <Show when={aggregateOutcomes().total > 0}>
+                    <SearchOutcomesBanner outcomes={aggregateOutcomes()} paperCount={paperCount()} />
+                </Show>
                 {resultEntries().map(([key, res]) => (
                     <ReplicationSummary q={key} data={res} />
                 ))}
@@ -73,4 +103,4 @@ export const ReplicationSearchPanel = (props: ReplicationSearchPanelProps) => {
             </Show>
         </div>
     );
-}
+};

--- a/src/components/replication/SearchOutcomesBanner.tsx
+++ b/src/components/replication/SearchOutcomesBanner.tsx
@@ -1,0 +1,85 @@
+import { createMemo, For } from "solid-js";
+
+type OutcomeCounts = {
+    success: number;
+    failed: number;
+    mixed: number;
+    partial: number;
+    total: number;
+    categorizedTotal: number;
+};
+
+type SearchOutcomesBannerProps = {
+    outcomes: OutcomeCounts;
+    paperCount: number;
+};
+
+type Segment = {
+    key: keyof Omit<OutcomeCounts, "total" | "categorizedTotal">;
+    label: string;
+    color: string;
+};
+
+const SEGMENTS: Segment[] = [
+    { key: "success", label: "Successful", color: "var(--success)"  },
+    { key: "failed",  label: "Failed",     color: "var(--error)"    },
+    { key: "mixed",   label: "Mixed",      color: "var(--warning)"  },
+    { key: "partial", label: "Partial",    color: "var(--primary)"  },
+];
+
+export const SearchOutcomesBanner = (props: SearchOutcomesBannerProps) => {
+    const segments = createMemo(() =>
+        SEGMENTS.filter(s => props.outcomes[s.key] > 0));
+
+    const pct = (key: keyof Omit<OutcomeCounts, "total" | "categorizedTotal">) =>
+        props.outcomes.categorizedTotal > 0
+            ? (props.outcomes[key] / props.outcomes.categorizedTotal) * 100
+            : 0;
+
+    return (
+        <div style={{
+            background: "var(--white)",
+            border: "1px solid var(--border-light)",
+            "border-radius": "var(--radius)",
+            padding: "12px 16px 10px",
+            "margin-bottom": "12px",
+            "font-family": "var(--font-body)",
+        }}>
+            <p style={{
+                "font-size": "11px",
+                "font-weight": "600",
+                color: "var(--text-muted)",
+                "text-transform": "uppercase",
+                "letter-spacing": "0.06em",
+                "margin-bottom": "8px",
+            }}>
+                {props.outcomes.total} Replication{props.outcomes.total !== 1 ? "s" : ""} · {props.paperCount} Paper{props.paperCount !== 1 ? "s" : ""}
+            </p>
+            <div style={{ display: "flex", width: "100%", height: "28px", "border-radius": "var(--radius)", overflow: "hidden", gap: "2px" }}>
+                <For each={segments()}>
+                    {(s) => (
+                        <div
+                            style={{ background: s.color, width: `${pct(s.key)}%`, display: "flex", "align-items": "center", "justify-content": "center" }}
+                            title={`${s.label}: ${props.outcomes[s.key]}`}
+                        >
+                            <span style={{ color: "white", "font-size": "11px", "font-weight": "700", "text-shadow": "0 1px 2px rgba(0,0,0,0.25)", "user-select": "none" }}>
+                                {props.outcomes[s.key]}
+                            </span>
+                        </div>
+                    )}
+                </For>
+            </div>
+            <div style={{ display: "flex", width: "100%", gap: "2px", "margin-top": "4px" }}>
+                <For each={segments()}>
+                    {(s) => (
+                        <div style={{ width: `${pct(s.key)}%`, "text-align": "center", overflow: "hidden" }}>
+                            <span style={{ "font-size": "10px", "font-weight": "600", color: s.color, "white-space": "nowrap" }}>
+                                {s.label}
+                            </span>
+                        </div>
+                    )}
+                </For>
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
Introduce a SearchOutcomesBanner component to visualize aggregated replication outcomes and wire it into both the main App results view and the ReplicationSearchPanel. Add createMemo-based aggregateOutcomes and paperCount calculations (using formatReplicationResponse) to compute success/failed/mixed/partial/total counts and show the banner when outcomes exist. Also update types to allow OriginalPaper.record to be null, and reduce the search debounce to 300ms in ReplicationSearchPanel. Minor exports/formatting fixes.