### PR TITLE
Add reference import modal and DOI parsing/lookup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import { DetailView } from "./components/layout/DetailView";
 import { NoDataState } from "./components/layout/NoDataState";
 import { Footer } from "./components/Footer";
+import { ReferenceImportModal } from "./components/layout/ReferenceImportModal";
 
 const isDoi = (s: string) => /^10\.\d{4,}\//.test(s.trim());
 
@@ -43,12 +44,30 @@ function App() {
   const [isLoading, setIsLoading] = createSignal(false);
   const [hasSearched, setHasSearched] = createSignal(false);
   const [hasEverSearched, setHasEverSearched] = createSignal(false);
+  const [typeFilter, setTypeFilter] = createSignal<"original" | "replication">("original");
+  const [showImportModal, setShowImportModal] = createSignal(false);
+
+  const filteredResults = createMemo(() => {
+    const filter = typeFilter();
+    return Object.entries(results()).filter(([, paper]) => {
+      const rep = formatReplicationResponse(paper);
+      const isOriginal = (rep.replications?.length || 0) > 0;
+      const isReplication = (rep.originals?.length || 0) > 0;
+      if (filter === "original") return isOriginal;
+      return isReplication;
+    });
+  });
 
   const aggregateOutcomes = createMemo(() => {
     const res = results();
+    const filter = typeFilter();
     const counts = Object.values(res).reduce(
       (acc, paper) => {
         const rep = formatReplicationResponse(paper);
+        const isOriginal = (rep.replications?.length || 0) > 0;
+        const isReplication = (rep.originals?.length || 0) > 0;
+        if (filter === "original" && !isOriginal) return acc;
+        if (filter === "replication" && !isReplication) return acc;
         acc.success += rep.outcomes?.success ?? 0;
         acc.failed  += rep.outcomes?.failed  ?? 0;
         acc.mixed   += rep.outcomes?.mixed   ?? 0;
@@ -61,9 +80,18 @@ function App() {
     return { ...counts, categorizedTotal: counts.success + counts.failed + counts.mixed + counts.partial };
   });
 
-  const paperCount = createMemo(() =>
-    Object.values(results()).filter(p => p.record != null).length
-  );
+  const paperCount = createMemo(() => {
+    const filter = typeFilter();
+    return Object.values(results()).filter(p => {
+      if (!p.record) return false;
+      const rep = formatReplicationResponse(p);
+      const isOriginal = (rep.replications?.length || 0) > 0;
+      const isReplication = (rep.originals?.length || 0) > 0;
+      if (filter === "original") return isOriginal;
+      if (filter === "replication") return isReplication;
+      return true;
+    }).length;
+  });
 
   const paperRefs: Record<string, HTMLDivElement> = {};
   let rightPanelRef: HTMLDivElement | undefined;
@@ -366,6 +394,7 @@ function App() {
             doDoiSearch(allTags);
           }
         }}
+        onImportClick={() => setShowImportModal(true)}
       />
 
       <div
@@ -384,6 +413,8 @@ function App() {
             onSelect={(doi) => scrollToPaper(doi)}
             isLoading={isLoading()}
             hasSearched={hasSearched()}
+            typeFilter={typeFilter()}
+            onTypeFilterChange={setTypeFilter}
           />
         </Show>
 
@@ -418,6 +449,7 @@ function App() {
                             onSearchSubmit={doSearch}
                             onSearchModeChange={handleSearchModeChange}
                             onExampleClick={handleExampleClick}
+                            onImportClick={() => setShowImportModal(true)}
                           />
                         }
                       >
@@ -495,7 +527,7 @@ function App() {
               <Show when={aggregateOutcomes().total > 0}>
                 <SearchOutcomesBanner outcomes={aggregateOutcomes()} paperCount={paperCount()} />
               </Show>
-              <For each={Object.entries(results())}>
+              <For each={filteredResults()}>
               {([doi, paper]) => (
                 <div
                   data-doi={doi}
@@ -518,6 +550,18 @@ function App() {
           </Show>
         </div>
       </div>
+
+      <ReferenceImportModal
+        open={showImportModal()}
+        onClose={() => setShowImportModal(false)}
+        onSearch={(dois) => {
+          setSearchMode("doi");
+          setTags(dois);
+          setInputValue("");
+          syncUrl(dois);
+          doDoiSearch(dois);
+        }}
+      />
 
       <Footer />
     </>

--- a/src/components/layout/ReferenceImportModal.tsx
+++ b/src/components/layout/ReferenceImportModal.tsx
@@ -1,0 +1,389 @@
+import { createSignal, createEffect, For, Show, onCleanup, onMount } from "solid-js";
+import { parseReferences } from "../../utils/referenceParser";
+import { lookupAll, type LookupResult } from "../../utils/doiLookup";
+
+type Tab = "paste" | "upload";
+type Stage = "input" | "processing" | "results";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSearch: (dois: string[]) => void;
+};
+
+const SourceBadge = (props: { source: LookupResult["source"] }) => {
+  const map: Record<string, { label: string; cls: string }> = {
+    direct:   { label: "DOI",       cls: "rim-badge-direct"   },
+    crossref: { label: "CrossRef",  cls: "rim-badge-crossref" },
+    openalex: { label: "OpenAlex",  cls: "rim-badge-openalex" },
+    none:     { label: "Not found", cls: "rim-badge-none"     },
+  };
+  const info = () => map[props.source] ?? map.none;
+  return <span class={`rim-badge ${info().cls}`}>{info().label}</span>;
+};
+
+export const ReferenceImportModal = (props: Props) => {
+  const [tab, setTab] = createSignal<Tab>("paste");
+  const [stage, setStage] = createSignal<Stage>("input");
+  const [text, setText] = createSignal("");
+  const [fileName, setFileName] = createSignal<string | null>(null);
+  const [results, setResults] = createSignal<LookupResult[]>([]);
+  const [progress, setProgress] = createSignal({ done: 0, total: 0 });
+  const [error, setError] = createSignal<string | null>(null);
+  const [dragOver, setDragOver] = createSignal(false);
+
+  let abortController: AbortController | null = null;
+  let fileInputRef: HTMLInputElement | undefined;
+
+  const reset = () => {
+    abortController?.abort();
+    setTab("paste");
+    setStage("input");
+    setText("");
+    setFileName(null);
+    setResults([]);
+    setProgress({ done: 0, total: 0 });
+    setError(null);
+    setDragOver(false);
+  };
+
+  const handleClose = () => {
+    reset();
+    props.onClose();
+  };
+
+  createEffect(() => {
+    if (!props.open) reset();
+  });
+
+  const handleKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape" && props.open) handleClose();
+  };
+  onMount(() => window.addEventListener("keydown", handleKey));
+  onCleanup(() => {
+    window.removeEventListener("keydown", handleKey);
+    abortController?.abort();
+  });
+
+  const loadFile = (file: File) => {
+    if (!file.name.endsWith(".txt") && file.type !== "text/plain") {
+      setError("Only .txt files are supported.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setText((e.target?.result as string) ?? "");
+      setFileName(file.name);
+      setError(null);
+    };
+    reader.readAsText(file);
+  };
+
+  const handleFileInput = (e: Event) => {
+    const file = (e.currentTarget as HTMLInputElement).files?.[0];
+    if (file) loadFile(file);
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer?.files?.[0];
+    if (file) loadFile(file);
+  };
+
+  const runExtraction = async () => {
+    const raw = text().trim();
+    if (!raw) { setError("Please enter or upload some text first."); return; }
+    setError(null);
+
+    const refs = parseReferences(raw);
+    if (refs.length === 0) { setError("No references detected in the text."); return; }
+
+    setStage("processing");
+    setProgress({ done: 0, total: refs.length });
+
+    abortController = new AbortController();
+    const found = await lookupAll(
+      refs,
+      (done, total) => setProgress({ done, total }),
+      abortController.signal,
+    );
+
+    setResults(found);
+    setStage("results");
+  };
+
+  const toggleResult = (index: number) => {
+    setResults((prev) =>
+      prev.map((r, i) =>
+        i === index && r.status !== "not_found"
+          ? { ...r, selected: !r.selected }
+          : r,
+      ),
+    );
+  };
+
+  const selectedDois = () =>
+    results()
+      .filter((r) => r.selected && r.doi)
+      .map((r) => r.doi!);
+
+  const handleSearch = () => {
+    const dois = selectedDois();
+    if (dois.length === 0) return;
+    props.onSearch(dois);
+    handleClose();
+  };
+
+  const foundCount = () => results().filter((r) => r.status !== "not_found").length;
+  const notFoundCount = () => results().filter((r) => r.status === "not_found").length;
+
+  return (
+    <Show when={props.open}>
+      <div class="rim-backdrop" onClick={handleClose} role="presentation">
+        <div
+          class="rim-modal"
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Import References"
+        >
+          {/* Header */}
+          <div class="rim-header">
+            <div>
+              <h2 class="rim-title">Import References</h2>
+              <p class="rim-subtitle">
+                Extract DOIs from a reference list — missing ones are looked up via CrossRef &amp; OpenAlex.
+              </p>
+            </div>
+            <button class="rim-close" onClick={handleClose} aria-label="Close">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Input stage */}
+          <Show when={stage() === "input"}>
+            {/* Tab bar */}
+            <div class="rim-tabs">
+              <button
+                class={`rim-tab ${tab() === "paste" ? "active" : ""}`}
+                onClick={() => setTab("paste")}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M9 2h6l2 2v2H7V4z" /><rect x="5" y="6" width="14" height="16" rx="1" />
+                  <path d="M9 12h6M9 16h4" />
+                </svg>
+                Paste text
+              </button>
+              <button
+                class={`rim-tab ${tab() === "upload" ? "active" : ""}`}
+                onClick={() => setTab("upload")}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                  <polyline points="17 8 12 3 7 8" />
+                  <line x1="12" y1="3" x2="12" y2="15" />
+                </svg>
+                Upload .txt
+              </button>
+            </div>
+
+            <div class="rim-body">
+              <Show when={tab() === "paste"}>
+                <textarea
+                  class="rim-textarea"
+                  placeholder={"Paste your reference list here…\n\nExamples:\n  10.1037/a0012345\n  Smith, J. (2020). Title. Journal, 10(2). https://doi.org/10.1037/a0012345\n  [1] Jones A. Title here. J. 2019;5:1–10."}
+                  value={text()}
+                  onInput={(e) => { setText(e.currentTarget.value); setError(null); }}
+                  spellcheck={false}
+                />
+              </Show>
+
+              <Show when={tab() === "upload"}>
+                <div
+                  class={`rim-dropzone ${dragOver() ? "drag-over" : ""} ${fileName() ? "has-file" : ""}`}
+                  onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+                  onDragLeave={() => setDragOver(false)}
+                  onDrop={handleDrop}
+                  onClick={() => fileInputRef?.click()}
+                >
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".txt,text/plain"
+                    style={{ display: "none" }}
+                    onChange={handleFileInput}
+                  />
+                  <Show
+                    when={fileName()}
+                    fallback={
+                      <>
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="rim-drop-icon">
+                          <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                          <polyline points="17 8 12 3 7 8" />
+                          <line x1="12" y1="3" x2="12" y2="15" />
+                        </svg>
+                        <p class="rim-drop-label">Drop a .txt file here or <span class="rim-drop-link">click to browse</span></p>
+                      </>
+                    }
+                  >
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="rim-drop-icon-ok">
+                      <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                      <polyline points="14 2 14 8 20 8" />
+                    </svg>
+                    <p class="rim-drop-filename">{fileName()}</p>
+                    <p class="rim-drop-change">Click to change file</p>
+                  </Show>
+                </div>
+
+                <Show when={text() && fileName()}>
+                  <p class="rim-file-preview-label">Preview</p>
+                  <div class="rim-file-preview">{text().substring(0, 600)}{text().length > 600 ? "…" : ""}</div>
+                </Show>
+              </Show>
+
+              <Show when={error()}>
+                <p class="rim-error">{error()}</p>
+              </Show>
+            </div>
+
+            <div class="rim-footer">
+              <button class="rim-btn-ghost" onClick={handleClose}>Cancel</button>
+              <button
+                class="rim-btn-primary"
+                onClick={runExtraction}
+                disabled={!text().trim()}
+              >
+                Extract &amp; look up DOIs
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+              </button>
+            </div>
+          </Show>
+
+          {/* Processing stage */}
+          <Show when={stage() === "processing"}>
+            <div class="rim-body rim-body-center">
+              <div class="rim-progress-wrap">
+                <div class="rim-spinner" />
+                <p class="rim-progress-text">
+                  Looking up DOIs… {progress().done} / {progress().total}
+                </p>
+                <div class="rim-progress-bar-track">
+                  <div
+                    class="rim-progress-bar-fill"
+                    style={{
+                      width: progress().total > 0
+                        ? `${(progress().done / progress().total) * 100}%`
+                        : "0%",
+                    }}
+                  />
+                </div>
+                <p class="rim-progress-sub">Querying CrossRef and OpenAlex for unresolved references…</p>
+              </div>
+            </div>
+            <div class="rim-footer">
+              <button class="rim-btn-ghost" onClick={() => { abortController?.abort(); setStage("input"); }}>
+                Cancel
+              </button>
+            </div>
+          </Show>
+
+          {/* Results stage */}
+          <Show when={stage() === "results"}>
+            <div class="rim-results-summary">
+              <span class="rim-sum-item rim-sum-found">{foundCount()} resolved</span>
+              <Show when={notFoundCount() > 0}>
+                <span class="rim-sum-sep">·</span>
+                <span class="rim-sum-item rim-sum-none">{notFoundCount()} not found</span>
+              </Show>
+              <span class="rim-sum-sep">·</span>
+              <span class="rim-sum-hint">Uncheck any DOIs you want to exclude</span>
+            </div>
+
+            <div class="rim-results-list">
+              <For each={results()}>
+                {(result, i) => (
+                  <div
+                    class={`rim-result-row ${result.status === "not_found" ? "rim-row-none" : ""} ${result.selected ? "rim-row-selected" : ""}`}
+                    onClick={() => toggleResult(i())}
+                  >
+                    <div class="rim-row-check">
+                      <Show
+                        when={result.status !== "not_found"}
+                        fallback={
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                          </svg>
+                        }
+                      >
+                        <div class={`rim-checkbox ${result.selected ? "checked" : ""}`}>
+                          <Show when={result.selected}>
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+                              <polyline points="20 6 9 17 4 12" />
+                            </svg>
+                          </Show>
+                        </div>
+                      </Show>
+                    </div>
+
+                    <div class="rim-row-body">
+                      <div class="rim-row-top">
+                        <SourceBadge source={result.source} />
+                        <Show when={result.doi}>
+                          <code class="rim-row-doi">{result.doi}</code>
+                        </Show>
+                      </div>
+                      <Show when={result.foundTitle}>
+                        <p class="rim-row-title">{result.foundTitle}</p>
+                      </Show>
+                      <p class="rim-row-raw" title={result.ref.raw}>
+                        {result.ref.raw.length > 120
+                          ? result.ref.raw.substring(0, 120) + "…"
+                          : result.ref.raw}
+                      </p>
+                      <Show when={result.status === "not_found"}>
+                        <p class="rim-row-unresolved">
+                          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <circle cx="12" cy="12" r="10" />
+                            <line x1="12" y1="8" x2="12" y2="12" />
+                            <line x1="12" y1="16" x2="12.01" y2="16" />
+                          </svg>
+                          Couldn't find a DOI for this reference. Please look it up manually (e.g. on{" "}
+                          <a href="https://search.crossref.org" target="_blank" rel="noopener">CrossRef</a>
+                          {" "}or{" "}
+                          <a href="https://openalex.org" target="_blank" rel="noopener">OpenAlex</a>
+                          ) and add it to the search directly.
+                        </p>
+                      </Show>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+
+            <div class="rim-footer">
+              <button class="rim-btn-ghost" onClick={() => setStage("input")}>
+                ← Back
+              </button>
+              <button
+                class="rim-btn-primary"
+                onClick={handleSearch}
+                disabled={selectedDois().length === 0}
+              >
+                Search {selectedDois().length} paper{selectedDois().length !== 1 ? "s" : ""}
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                  <circle cx="11" cy="11" r="8" /><path d="M21 21l-4.3-4.3" />
+                </svg>
+              </button>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/src/components/layout/StudyListPanel.tsx
+++ b/src/components/layout/StudyListPanel.tsx
@@ -1,9 +1,9 @@
-import { createSignal, createEffect, For, Show } from "solid-js";
+import { createEffect, For, Show } from "solid-js";
 import type { OriginalPaper, FormattedDOIResult } from "../../@types";
 import { formatReplicationResponse } from "../../api/formatter";
 import { formatAuthors, renderAuthors, na } from "../../utils/formatter";
 
-type TypeFilter = "all" | "original" | "replication";
+type TypeFilter = "original" | "replication";
 
 type StudyListPanelProps = {
   results: Record<string, OriginalPaper>;
@@ -11,6 +11,8 @@ type StudyListPanelProps = {
   onSelect: (doi: string) => void;
   isLoading: boolean;
   hasSearched: boolean;
+  typeFilter: TypeFilter;
+  onTypeFilterChange: (f: TypeFilter) => void;
 };
 
 type OutcomeStatus = "failed" | "mixed" | "partial" | "successful" | "blank";
@@ -49,8 +51,6 @@ const PrintIcon = () => (
 );
 
 export const StudyListPanel = (props: StudyListPanelProps) => {
-  const [typeFilter, setTypeFilter] = createSignal<TypeFilter>("all");
-
   const allEntries = () =>
     Object.entries(props.results)
       .map(([doi, paper]) => {
@@ -67,8 +67,7 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
       });
 
   const entries = () => {
-    const filter = typeFilter();
-    if (filter === "all") return allEntries();
+    const filter = props.typeFilter;
     if (filter === "original") return allEntries().filter((e) => e.isOriginal);
     return allEntries().filter((e) => e.isReplication);
   };
@@ -83,11 +82,7 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
     if (visible.length === 0) return;
 
     const filterLabel =
-      typeFilter() === "all"
-        ? "All Studies"
-        : typeFilter() === "original"
-          ? "Original Studies"
-          : "Replication Studies";
+      props.typeFilter === "original" ? "Original Studies" : "Replication Studies";
     const esc = (s: string) =>
       s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
@@ -279,24 +274,18 @@ footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #ddd; font
         }
       >
         <div class="sli-filter-bar">
-          <button
-            class={`sli-filter-btn ${typeFilter() === "all" ? "active" : ""}`}
-            onClick={() => setTypeFilter("all")}
-          >
-            All <span class="sli-filter-count">{totalCount()}</span>
-          </button>
           <Show when={originalCount() > 0}>
             <button
-              class={`sli-filter-btn original ${typeFilter() === "original" ? "active" : ""}`}
-              onClick={() => setTypeFilter("original")}
+              class={`sli-filter-btn original ${props.typeFilter === "original" ? "active" : ""}`}
+              onClick={() => props.onTypeFilterChange("original")}
             >
               Original <span class="sli-filter-count">{originalCount()}</span>
             </button>
           </Show>
           <Show when={replicationCount() > 0}>
             <button
-              class={`sli-filter-btn replication ${typeFilter() === "replication" ? "active" : ""}`}
-              onClick={() => setTypeFilter("replication")}
+              class={`sli-filter-btn replication ${props.typeFilter === "replication" ? "active" : ""}`}
+              onClick={() => props.onTypeFilterChange("replication")}
             >
               Replication{" "}
               <span class="sli-filter-count">{replicationCount()}</span>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -19,6 +19,7 @@ type TopBarProps = {
   onNavigateSearch?: (tags: string[]) => void;
   onSearchModeChange: (mode: SearchMode) => void;
   onInputRef?: (el: HTMLInputElement) => void;
+  onImportClick?: () => void;
 };
 
 const DOI_DELIMITER_KEYS = new Set([",", ";", " ", "Tab"]);
@@ -189,14 +190,34 @@ export const TopBar = (props: TopBarProps) => {
           </A>
         </div>
         <Show when={props.showSearch !== false}>
-          <div
-            class="topbar-search topbar-search-desktop"
-            onClick={() => inputRef?.focus()}
-          >
-            {searchBar((el) => {
-              inputRef = el;
-              props.onInputRef?.(el);
-            })}
+          <div class="topbar-search-group topbar-search-desktop">
+            <div
+              class="topbar-search"
+              onClick={() => inputRef?.focus()}
+            >
+              {searchBar((el) => {
+                inputRef = el;
+                props.onInputRef?.(el);
+              })}
+            </div>
+            <Show when={!!props.onImportClick}>
+              <span class="topbar-import-sep" aria-hidden="true" />
+              <button
+                class="topbar-import-btn"
+                onClick={() => props.onImportClick!()}
+                title="Import references from text or file"
+                type="button"
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="8" y1="13" x2="16" y2="13" />
+                  <line x1="8" y1="17" x2="16" y2="17" />
+                  <polyline points="10 9 9 9 8 9" />
+                </svg>
+                Import refs
+              </button>
+            </Show>
           </div>
         </Show>
         <div class="topbar-right topbar-right-desktop">

--- a/src/components/layout/WelcomeState.tsx
+++ b/src/components/layout/WelcomeState.tsx
@@ -16,6 +16,7 @@ type WelcomeStateProps = {
   onSearchSubmit: () => void;
   onSearchModeChange: (mode: SearchMode) => void;
   onExampleClick: (query: string) => void;
+  onImportClick?: () => void;
 };
 
 export const exampleSearches = [
@@ -193,6 +194,31 @@ export const WelcomeState = (props: WelcomeStateProps) => {
           Search
         </button>
       </div>
+
+      {props.onImportClick && (
+        <>
+          <div class="welcome-import-or-divider">
+            <span>or</span>
+          </div>
+          <button class="welcome-import-card" onClick={props.onImportClick} type="button">
+          <div class="welcome-import-card-icon">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+              <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="8" y1="13" x2="16" y2="13" />
+              <line x1="8" y1="17" x2="16" y2="17" />
+            </svg>
+          </div>
+          <div class="welcome-import-card-body">
+            <span class="welcome-import-card-title">Import a reference list</span>
+            <span class="welcome-import-card-sub">Paste or upload a .txt file — DOIs extracted &amp; resolved automatically</span>
+          </div>
+          <svg class="welcome-import-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+          </button>
+        </>
+      )}
 
       <div class="welcome-examples">
         <div class="welcome-examples-label">Example searches</div>

--- a/src/index.css
+++ b/src/index.css
@@ -722,6 +722,84 @@ body {
   margin-bottom: 1.25rem;
   max-width: 380px;
 }
+.welcome-import-or-divider {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 480px;
+  gap: 10px;
+  color: var(--text-faint);
+  font-size: 12px;
+  margin: -8px 0 0;
+}
+.welcome-import-or-divider::before,
+.welcome-import-or-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-light);
+}
+
+.welcome-import-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  max-width: 480px;
+  background: var(--white);
+  border: 1.5px dashed var(--info-border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+  margin-bottom: 1.75rem;
+  transition: all var(--transition-fast);
+  box-shadow: var(--shadow-sm);
+}
+.welcome-import-card:hover {
+  border-style: solid;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-faint);
+}
+.welcome-import-card-icon {
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  background: var(--primary-faint);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary);
+}
+.welcome-import-card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.welcome-import-card-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text);
+}
+.welcome-import-card-sub {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+.welcome-import-card-arrow {
+  flex-shrink: 0;
+  color: var(--text-faint);
+  transition: color var(--transition-fast), transform var(--transition-fast);
+}
+.welcome-import-card:hover .welcome-import-card-arrow {
+  color: var(--primary);
+  transform: translateX(2px);
+}
+
 .welcome-examples {
   display: flex;
   flex-direction: column;
@@ -782,7 +860,7 @@ body {
   padding: 0.35rem 0.4rem 0.35rem 0.85rem;
   width: 100%;
   max-width: 480px;
-  margin-bottom: 1.75rem;
+  margin-bottom: 0.75rem;
   transition: all var(--transition);
   box-shadow: var(--shadow-sm);
 }
@@ -2224,4 +2302,449 @@ body {
   font-style: italic;
   opacity: 0.8;
   font-size: 0.85em;
+}
+
+/* ─── Reference Import Modal ─────────────────────────────────────────────── */
+
+.rim-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.rim-modal {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: 100%;
+  max-width: 640px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rim-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 20px 0;
+  flex-shrink: 0;
+}
+
+.rim-title {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 3px;
+}
+
+.rim-subtitle {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.rim-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 2px;
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  transition: color var(--transition-fast);
+}
+.rim-close:hover { color: var(--text); }
+
+/* Tabs */
+.rim-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 14px 20px 0;
+  flex-shrink: 0;
+}
+
+.rim-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12.5px;
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--text-muted);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.rim-tab:hover { background: var(--surface); color: var(--text-secondary); }
+.rim-tab.active {
+  background: var(--primary-faint);
+  color: var(--primary);
+  border-color: var(--info-border);
+}
+
+/* Body */
+.rim-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 20px;
+  min-height: 0;
+}
+
+.rim-body-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 220px;
+}
+
+.rim-textarea {
+  width: 100%;
+  height: 240px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  font-family: "Menlo", "Consolas", monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--surface);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+.rim-textarea:focus { border-color: var(--primary); background: var(--white); }
+.rim-textarea::placeholder { color: var(--text-faint); }
+
+/* Drop zone */
+.rim-dropzone {
+  border: 2px dashed var(--border);
+  border-radius: var(--radius-lg);
+  padding: 40px 20px;
+  text-align: center;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+.rim-dropzone:hover,
+.rim-dropzone.drag-over {
+  border-color: var(--primary);
+  background: var(--primary-faint);
+}
+.rim-dropzone.has-file { border-style: solid; border-color: var(--primary); background: var(--primary-faint); }
+.rim-drop-icon { color: var(--text-faint); }
+.rim-drop-icon-ok { color: var(--primary); }
+.rim-drop-label { font-size: 13px; color: var(--text-secondary); margin: 0; }
+.rim-drop-link { color: var(--primary); text-decoration: underline; }
+.rim-drop-filename { font-size: 13px; font-weight: 700; color: var(--primary); margin: 0; }
+.rim-drop-change { font-size: 11.5px; color: var(--text-muted); margin: 0; }
+
+.rim-file-preview-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: 12px 0 4px;
+}
+.rim-file-preview {
+  font-family: "Menlo", "Consolas", monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 100px;
+  overflow: hidden;
+}
+
+.rim-error {
+  font-size: 12.5px;
+  color: var(--error);
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  margin-top: 10px;
+}
+
+/* Processing */
+.rim-progress-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  max-width: 340px;
+}
+.rim-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: rim-spin 0.7s linear infinite;
+}
+@keyframes rim-spin { to { transform: rotate(360deg); } }
+
+.rim-progress-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+.rim-progress-sub {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+}
+.rim-progress-bar-track {
+  width: 100%;
+  height: 4px;
+  background: var(--border-light);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.rim-progress-bar-fill {
+  height: 100%;
+  background: var(--primary);
+  border-radius: 2px;
+  transition: width 0.2s ease;
+}
+
+/* Results */
+.rim-results-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  background: var(--surface);
+  border-top: 1px solid var(--border-light);
+  flex-shrink: 0;
+  font-size: 12px;
+}
+.rim-sum-item { font-weight: 700; }
+.rim-sum-found { color: var(--success); }
+.rim-sum-none  { color: var(--text-muted); }
+.rim-sum-sep   { color: var(--border); }
+.rim-sum-hint  { color: var(--text-faint); font-weight: 400; }
+
+.rim-results-list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 8px 0;
+}
+
+.rim-result-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 20px;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border-bottom: 1px solid var(--border-light);
+}
+.rim-result-row:last-child { border-bottom: none; }
+.rim-result-row:hover:not(.rim-row-none) { background: var(--surface); }
+.rim-row-none { opacity: 0.55; cursor: default; }
+
+.rim-row-check {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+  color: var(--text-muted);
+}
+
+.rim-checkbox {
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid var(--border);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--white);
+  transition: all var(--transition-fast);
+}
+.rim-checkbox.checked {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+}
+
+.rim-row-body { flex: 1; min-width: 0; }
+
+.rim-row-top {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  margin-bottom: 3px;
+}
+
+.rim-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.rim-badge-direct   { background: var(--success-bg); color: var(--success); }
+.rim-badge-crossref { background: var(--primary-faint); color: var(--primary); }
+.rim-badge-openalex { background: var(--warning-bg); color: var(--warning); }
+.rim-badge-none     { background: var(--surface-alt); color: var(--text-muted); }
+
+.rim-row-doi {
+  font-family: "Menlo", "Consolas", monospace;
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+
+.rim-row-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rim-row-raw {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rim-row-unresolved {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  font-size: 11.5px;
+  color: var(--warning);
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-border);
+  border-radius: var(--radius);
+  padding: 5px 8px;
+  margin-top: 5px;
+  line-height: 1.45;
+}
+.rim-row-unresolved svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.rim-row-unresolved a {
+  color: var(--warning);
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+/* Footer */
+.rim-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border-light);
+  flex-shrink: 0;
+}
+
+.rim-btn-ghost {
+  padding: 7px 14px;
+  font-size: 13px;
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.rim-btn-ghost:hover { background: var(--surface); border-color: var(--border); }
+
+.rim-btn-primary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-family: var(--font-body);
+  font-weight: 700;
+  color: var(--white);
+  background: var(--primary);
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+.rim-btn-primary:hover:not(:disabled) { background: var(--primary-dark); }
+.rim-btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* Import refs button + search group in TopBar */
+.topbar-search-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.topbar-import-sep {
+  width: 1px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+}
+
+.topbar-import-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0.35rem 0.6rem;
+  font-size: 12px;
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.5);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.topbar-import-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
 }

--- a/src/utils/doiLookup.ts
+++ b/src/utils/doiLookup.ts
@@ -1,0 +1,109 @@
+import type { ParsedReference } from "./referenceParser";
+
+export type LookupStatus = "found" | "resolved" | "not_found";
+
+export type LookupResult = {
+  ref: ParsedReference;
+  doi: string | null;
+  foundTitle?: string;
+  score?: number;
+  source: "direct" | "crossref" | "openalex" | "none";
+  status: LookupStatus;
+  selected: boolean;
+};
+
+async function crossRefLookup(
+  query: string,
+): Promise<{ doi: string; title: string; score: number } | null> {
+  try {
+    const url = `https://api.crossref.org/works?query.bibliographic=${encodeURIComponent(query)}&rows=1&select=DOI,title,score&mailto=keegangeorgevaz@gmail.com`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const item = data?.message?.items?.[0];
+    if (!item || (item.score ?? 0) < 40) return null;
+    return {
+      doi: item.DOI as string,
+      title: Array.isArray(item.title) ? item.title[0] : (item.title ?? ""),
+      score: item.score as number,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function openAlexLookup(
+  query: string,
+): Promise<{ doi: string; title: string } | null> {
+  try {
+    const url = `https://api.openalex.org/works?search=${encodeURIComponent(query)}&filter=has_doi:true&per-page=1&select=doi,title`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const item = data?.results?.[0];
+    if (!item?.doi) return null;
+    return {
+      doi: (item.doi as string).replace("https://doi.org/", ""),
+      title: (item.title as string) ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function lookupSingle(ref: ParsedReference): Promise<LookupResult> {
+  if (ref.doi) {
+    return { ref, doi: ref.doi, source: "direct", status: "found", selected: true };
+  }
+
+  const cr = await crossRefLookup(ref.queryText);
+  if (cr) {
+    return {
+      ref,
+      doi: cr.doi,
+      foundTitle: cr.title,
+      score: cr.score,
+      source: "crossref",
+      status: "resolved",
+      selected: true,
+    };
+  }
+
+  const oa = await openAlexLookup(ref.queryText);
+  if (oa) {
+    return {
+      ref,
+      doi: oa.doi,
+      foundTitle: oa.title,
+      source: "openalex",
+      status: "resolved",
+      selected: true,
+    };
+  }
+
+  return { ref, doi: null, source: "none", status: "not_found", selected: false };
+}
+
+const CONCURRENCY = 3;
+const BATCH_DELAY_MS = 250;
+
+export async function lookupAll(
+  refs: ParsedReference[],
+  onProgress: (done: number, total: number) => void,
+  signal?: AbortSignal,
+): Promise<LookupResult[]> {
+  const results: LookupResult[] = [];
+
+  for (let i = 0; i < refs.length; i += CONCURRENCY) {
+    if (signal?.aborted) break;
+    const batch = refs.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(batch.map(lookupSingle));
+    results.push(...batchResults);
+    onProgress(results.length, refs.length);
+    if (i + CONCURRENCY < refs.length) {
+      await new Promise<void>((resolve) => setTimeout(resolve, BATCH_DELAY_MS));
+    }
+  }
+
+  return results;
+}

--- a/src/utils/referenceParser.ts
+++ b/src/utils/referenceParser.ts
@@ -1,0 +1,125 @@
+const DOI_RE = /\b(10\.\d{4,}\/[^\s"'<>[\]{}|\\^`]+)/g;
+
+function cleanDoi(doi: string): string {
+  return doi.replace(/[.,;)\]>]+$/, "");
+}
+
+export type ParsedReference = {
+  raw: string;
+  doi: string | null;
+  queryText: string;
+};
+
+function extractDoiFromText(text: string): string | null {
+  const re = new RegExp(DOI_RE.source, "g");
+  const match = re.exec(text);
+  return match ? cleanDoi(match[1]) : null;
+}
+
+function buildQueryText(ref: string): string {
+  // Strip leading numbering: [1], 1., (1)
+  let s = ref.replace(/^\s*[\[(]?\d+[\].)]\s*/, "");
+
+  // Try APA-style: "Author (Year). Title. Journal..."
+  const apaTitle = s.match(/\(\d{4}[a-z]?\)\.\s+([^.]{10,})\./);
+  if (apaTitle) return apaTitle[1].trim();
+
+  // Try to grab content after apparent author section (first comma or period block)
+  // Heuristic: take the longest contiguous non-author fragment
+  s = s.replace(/^[A-Z][^.]+\.\s+/, ""); // strip leading "Author, A.B." chunk
+  return s.substring(0, 250).trim();
+}
+
+// Returns true if a line looks like the start of a new reference entry.
+function looksLikeRefStart(line: string): boolean {
+  // Numbered: [1], 1., 1)
+  if (/^[\[(]?\d+[\].)]\s+\S/.test(line)) return true;
+  // APA-style: starts with Author, A. or Author, A., & ...
+  if (/^[A-Z][a-záéíóú''-]+,\s+[A-Z]/.test(line)) return true;
+  // Vancouver-style: starts with Author AB or LASTNAME A
+  if (/^[A-Z][a-z]+ [A-Z]{1,3}[,\s]/.test(line)) return true;
+  // Starts with a year: 2020. Title...
+  if (/^\d{4}\.\s+[A-Z]/.test(line)) return true;
+  return false;
+}
+
+export function splitIntoReferences(text: string): string[] {
+  const lines = text.split(/\r?\n/);
+  const refs: string[] = [];
+  let current = "";
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      if (current.trim()) {
+        refs.push(current.trim());
+        current = "";
+      }
+      continue;
+    }
+
+    // Numbered reference or detected ref-start while accumulating something different
+    const startsNew =
+      /^[\[(]?\d+[\].)]\s+\S/.test(trimmed) ||
+      (current.trim() && looksLikeRefStart(trimmed));
+
+    if (startsNew && current.trim()) {
+      refs.push(current.trim());
+      current = trimmed;
+    } else {
+      current = current ? `${current} ${trimmed}` : trimmed;
+    }
+  }
+
+  if (current.trim()) refs.push(current.trim());
+
+  const filtered = refs.filter((r) => r.length > 15);
+
+  // Last-resort: if everything collapsed into one entry but there are multiple
+  // substantial lines, treat each non-trivial line as its own reference.
+  if (filtered.length <= 1) {
+    const perLine = lines.map((l) => l.trim()).filter((l) => l.length > 20);
+    if (perLine.length > 1) return perLine;
+  }
+
+  return filtered;
+}
+
+export function parseReferences(text: string): ParsedReference[] {
+  // Fast path: text is just a list of raw DOIs (one per line / comma-separated)
+  const doiOnlyLines = text
+    .split(/[\r\n,;]+/)
+    .map((s) => s.trim())
+    .filter((s) => /^10\.\d{4,}\//.test(s));
+
+  const rawRefs = splitIntoReferences(text);
+
+  // If the whole text is raw DOIs and splitting gave nothing useful, use doi-only mode
+  if (doiOnlyLines.length > 0 && rawRefs.length === 0) {
+    return doiOnlyLines.map((doi) => ({
+      raw: doi,
+      doi: cleanDoi(doi),
+      queryText: doi,
+    }));
+  }
+
+  // If no reference-style entries, fall back to extracting every DOI in the text
+  if (rawRefs.length === 0) {
+    const all: string[] = [];
+    const re = new RegExp(DOI_RE.source, "g");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) all.push(cleanDoi(m[1]));
+    return [...new Set(all)].map((doi) => ({
+      raw: doi,
+      doi,
+      queryText: doi,
+    }));
+  }
+
+  return rawRefs.map((raw) => ({
+    raw,
+    doi: extractDoiFromText(raw),
+    queryText: buildQueryText(raw),
+  }));
+}


### PR DESCRIPTION
Introduce a ReferenceImportModal UI to paste or upload reference lists, extract DOIs, and resolve missing DOIs via CrossRef/OpenAlex. Add utils/referenceParser.ts to split and parse reference text and utils/doiLookup.ts to perform batched lookups (with basic concurrency, progress callbacks, and fallback ordering). Wire the modal into App, TopBar and WelcomeState (import button/entry points), and update StudyListPanel/App to support an original/replication type filter that affects visible results and aggregated counts. Include new CSS for the modal, dropzone, buttons and topbar import styling.