### PR TITLE
Filter null entries from results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,7 +209,8 @@ function App() {
   };
 
   const handleResults = (res: DOIResults) => {
-    const data = res.results || {};
+    const raw = res.results || {};
+    const data = Object.fromEntries(Object.entries(raw).filter(([, v]) => v != null)) as Record<string, OriginalPaper>;
     setResults(data);
 
     // Auto-switch filter if the current one has no matches


### PR DESCRIPTION
Avoid storing null/undefined entries from DOI responses. Introduce a raw variable for res.results and build data by filtering out entries with null/undefined values, then cast to Record<string, OriginalPaper> before calling setResults. This prevents null values from causing issues when rendering or processing results.