### PR TITLE
Add multi-select and export selected entries

### DIFF
--- a/src/components/layout/StudyListPanel.tsx
+++ b/src/components/layout/StudyListPanel.tsx
@@ -1,4 +1,4 @@
-import { createEffect, For, Show } from "solid-js";
+import { createEffect, createSignal, For, Show } from "solid-js";
 import type { OriginalPaper, FormattedDOIResult } from "../../@types";
 import { formatReplicationResponse } from "../../api/formatter";
 import { formatAuthors, renderAuthors, na } from "../../utils/formatter";
@@ -51,6 +51,24 @@ const PrintIcon = () => (
 );
 
 export const StudyListPanel = (props: StudyListPanelProps) => {
+  const [selectedDois, setSelectedDois] = createSignal<Set<string>>(new Set());
+
+  const toggleSelect = (doi: string, e: MouseEvent) => {
+    e.stopPropagation();
+    setSelectedDois((prev) => {
+      const next = new Set<string>(prev);
+      if (next.has(doi)) next.delete(doi);
+      else next.add(doi);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setSelectedDois(new Set(entries().map((e) => e.doi)));
+  };
+
+  const clearSelection = () => setSelectedDois(new Set<string>());
+
   const allEntries = () =>
     Object.entries(props.results)
       .map(([doi, paper]) => {
@@ -77,8 +95,10 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
   const replicationCount = () =>
     allEntries().filter((e) => e.isReplication).length;
 
-  const handleExportPdf = () => {
-    const visible = entries();
+  type EntryItem = ReturnType<typeof allEntries>[number];
+
+  const handleExportPdf = (entriesToExport?: EntryItem[]) => {
+    const visible = entriesToExport ?? entries();
     if (visible.length === 0) return;
 
     const filterLabel =
@@ -249,16 +269,34 @@ footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #ddd; font
       <div class="lp-header">
         <h3>Search Results</h3>
         <div class="lp-header-actions">
-          <Show when={totalCount() > 0}>
+          <Show when={selectedDois().size > 0}>
+            <span class="lp-select-count">{selectedDois().size} selected</span>
             <button
-              class="lp-export-btn"
-              onClick={handleExportPdf}
-              title="Export to PDF"
+              class="lp-export-btn lp-export-btn--selected"
+              onClick={() => {
+                const sel = selectedDois();
+                handleExportPdf(entries().filter((e) => sel.has(e.doi)));
+              }}
+              title="Export selected entries"
             >
               <PrintIcon /> Export
             </button>
+            <button
+              class="lp-clear-select-btn"
+              onClick={clearSelection}
+              title="Clear selection"
+            >
+              &times;
+            </button>
           </Show>
-          <Show when={totalCount() > 0}>
+          <Show when={selectedDois().size === 0 && totalCount() > 0}>
+            <button
+              class="lp-export-btn"
+              onClick={() => handleExportPdf()}
+              title="Export all to PDF"
+            >
+              <PrintIcon /> Export
+            </button>
             <span class="lp-count">
               {totalCount()} {totalCount() === 1 ? "study" : "studies"}
             </span>
@@ -291,6 +329,14 @@ footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #ddd; font
               <span class="sli-filter-count">{replicationCount()}</span>
             </button>
           </Show>
+          <Show when={entries().length > 1}>
+            <button
+              class="sli-select-all-btn"
+              onClick={() => selectedDois().size === entries().length ? clearSelection() : selectAll()}
+            >
+              {selectedDois().size === entries().length ? "Deselect all" : "Select all"}
+            </button>
+          </Show>
         </div>
       </Show>
 
@@ -310,7 +356,12 @@ footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #ddd; font
           <For each={entries()}>
             {(entry) => (
               <div
-                class={`sli ${props.selectedDoi === entry.doi ? "active" : ""}`}
+                classList={{
+                  sli: true,
+                  active: props.selectedDoi === entry.doi,
+                  "sli--checked": selectedDois().has(entry.doi),
+                  "sli--selecting": selectedDois().size > 0,
+                }}
                 ref={(el) => {
                   createEffect(() => {
                     if (props.selectedDoi === entry.doi) {
@@ -323,6 +374,18 @@ footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #ddd; font
                 }}
                 onClick={() => props.onSelect(entry.doi)}
               >
+                <div
+                  class="sli-checkbox"
+                  role="checkbox"
+                  aria-checked={selectedDois().has(entry.doi)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleSelect(entry.doi, e);
+                  }}
+                  title="Select entry"
+                >
+                  <span class="sli-checkbox-box" />
+                </div>
                 <div class={`sli-dot ${entry.status}`} />
                 <div class="sli-body">
                   <div class="sli-title">{entry.rep.title || entry.doi}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -378,6 +378,38 @@ body {
   color: var(--text-secondary);
   background: var(--surface);
 }
+.lp-export-btn--selected {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.lp-export-btn--selected:hover {
+  background: var(--primary-faint);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+.lp-select-count {
+  font-size: 10.5px;
+  color: var(--primary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.lp-clear-select-btn {
+  font-size: 13px;
+  line-height: 1;
+  padding: 0.1rem 0.35rem;
+  border-radius: 100px;
+  border: 1px solid var(--border-light);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-body);
+  transition: all var(--transition-fast);
+}
+.lp-clear-select-btn:hover {
+  border-color: var(--border);
+  color: var(--text-secondary);
+  background: var(--surface);
+}
 
 /* ─── Filter chips ─── */
 .lp-filters {
@@ -475,6 +507,24 @@ body {
   opacity: 0.7;
   margin-left: 0.15rem;
 }
+.sli-select-all-btn {
+  margin-left: auto;
+  font-size: 10.5px;
+  padding: 0.15rem 0.45rem;
+  border-radius: 100px;
+  border: 1px solid var(--border-light);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-weight: 500;
+  transition: all var(--transition-fast);
+}
+.sli-select-all-btn:hover {
+  border-color: var(--border);
+  color: var(--text-secondary);
+  background: var(--surface);
+}
 
 /* ─── Study list ─── */
 .study-list {
@@ -522,6 +572,55 @@ body {
   border-radius: 0 3px 3px 0;
   background: var(--primary);
 }
+/* ─── Checkbox ─── */
+.sli-checkbox {
+  display: none;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-top: 0.2rem;
+}
+.sli-checkbox input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+.sli-checkbox-box {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  border: 1.5px solid var(--border);
+  background: var(--white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+  flex-shrink: 0;
+}
+.sli:hover .sli-checkbox,
+.sli--selecting .sli-checkbox {
+  display: flex;
+}
+.sli--checked .sli-checkbox-box {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.sli--checked .sli-checkbox-box::after {
+  content: "";
+  display: block;
+  width: 8px;
+  height: 5px;
+  border-left: 1.5px solid white;
+  border-bottom: 1.5px solid white;
+  transform: rotate(-45deg) translateY(-1px);
+}
+.sli--checked {
+  background: var(--primary-faint);
+}
+
 .sli-dot {
   width: 9px;
   height: 9px;


### PR DESCRIPTION
Introduce multi-selection for study list entries and allow exporting only selected items. Adds selection state (createSignal), toggle/select-all/clear helpers, and a checkbox UI per entry (with classList updates for selection styling). Refactors handleExportPdf to accept an optional list of entries, and updates header actions to show selected count, export-selected and clear buttons, plus a select/deselect-all control. Includes accompanying CSS for checkbox visuals and new button styles.