### PR TITLE
Add toast notifications and error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import { DetailView } from "./components/layout/DetailView";
 import { NoDataState } from "./components/layout/NoDataState";
 import { Footer } from "./components/Footer";
 import { ReferenceImportModal } from "./components/layout/ReferenceImportModal";
+import { createToastState } from "./components/layout/Toast";
+import { HttpError } from "./utils/http";
 
 const isDoi = (s: string) => /^10\.\d{4,}\//.test(s.trim());
 
@@ -41,8 +43,19 @@ const debounce = <T extends unknown[]>(
   return call;
 };
 
+const toastDetails = (error: unknown): [string, string] => {
+  if (error instanceof HttpError) {
+    if (error.status === 408) return ["Search timed out", "The server took too long to respond. Please try again."];
+    if (error.status === 0) return ["Network error", "Check your connection and try again."];
+    if (error.status >= 500) return ["Server error", "Something went wrong on our end. Please try again later."];
+    if (error.status >= 400) return ["Search failed", `The request was rejected (${error.status}). Try a different query.`];
+  }
+  return ["Something went wrong", "An unexpected error occurred. Please try again."];
+};
+
 function App() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { show: showToast, ToastStack } = createToastState();
 
   const [tags, setTags] = createSignal<string[]>([]);
   const [inputValue, setInputValue] = createSignal("");
@@ -308,9 +321,9 @@ function App() {
     fetchMultipleDOIInfo(dois)
       .then(handleResults)
       .catch((error) => {
-        console.error("Error fetching DOI info:", error);
         setIsLoading(false);
         setResults({});
+        const [t, m] = toastDetails(error); showToast(t, m);
       });
   };
 
@@ -326,9 +339,9 @@ function App() {
     fetchFuzzySearch(query)
       .then(handleResults)
       .catch((error) => {
-        console.error("Error in fuzzy search:", error);
         setIsLoading(false);
         setResults({});
+        const [t, m] = toastDetails(error); showToast(t, m);
       });
   };
 
@@ -370,9 +383,9 @@ function App() {
     })
       .then(handleResults)
       .catch((error) => {
-        console.error("Error in advanced search:", error);
         setIsLoading(false);
         setResults({});
+        const [t, m] = toastDetails(error); showToast(t, m);
       });
   };
 
@@ -481,7 +494,7 @@ function App() {
           yearFrom,
           yearTo,
           outcomes: outcomes.length ? outcomes : undefined,
-        }).then(handleResults).catch(() => { setIsLoading(false); setResults({}); });
+        }).then(handleResults).catch((error) => { setIsLoading(false); setResults({}); const [t, m] = toastDetails(error); showToast(t, m); });
       }
     } else {
       // URL has no search params — reset to welcome state
@@ -779,6 +792,7 @@ function App() {
       />
 
       <Footer />
+      <ToastStack />
     </>
   );
 }

--- a/src/components/layout/Toast.tsx
+++ b/src/components/layout/Toast.tsx
@@ -1,0 +1,100 @@
+import { createSignal, For, onCleanup, type JSX } from "solid-js";
+
+export type ToastVariant = "error" | "warning" | "info";
+
+export type Toast = {
+  id: number;
+  title: string;
+  message: string;
+  variant: ToastVariant;
+};
+
+type ToastItemProps = {
+  toast: Toast;
+  onDismiss: (id: number) => void;
+};
+
+let nextId = 1;
+
+const AUTO_DISMISS_MS = 5000;
+
+const ICONS: Record<ToastVariant, () => JSX.Element> = {
+  error: () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  ),
+  warning: () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  ),
+  info: () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="16" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12.01" y2="8" />
+    </svg>
+  ),
+};
+
+const ToastItem = (props: ToastItemProps) => {
+  const [exiting, setExiting] = createSignal(false);
+
+  const dismiss = () => {
+    setExiting(true);
+    setTimeout(() => props.onDismiss(props.toast.id), 200);
+  };
+
+  const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
+  onCleanup(() => clearTimeout(timer));
+
+  return (
+    <div
+      classList={{
+        toast: true,
+        [`toast--${props.toast.variant}`]: true,
+        "toast--exit": exiting(),
+      }}
+      role="alert"
+    >
+      <span class="toast-icon">{ICONS[props.toast.variant]()}</span>
+      <div class="toast-body">
+        <div class="toast-title">{props.toast.title}</div>
+        <div class="toast-message">{props.toast.message}</div>
+      </div>
+      <button class="toast-close" aria-label="Dismiss" onClick={dismiss}>
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export const createToastState = () => {
+  const [toasts, setToasts] = createSignal<Toast[]>([]);
+
+  const dismiss = (id: number) =>
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+
+  const show = (title: string, message: string, variant: ToastVariant = "error") => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, title, message, variant }]);
+  };
+
+  const ToastStack = () => (
+    <div class="toast-stack" aria-live="assertive" aria-atomic="false">
+      <For each={toasts()}>
+        {(toast) => <ToastItem toast={toast} onDismiss={dismiss} />}
+      </For>
+    </div>
+  );
+
+  return { show, ToastStack };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -922,7 +922,9 @@ body {
 .welcome-import-card-arrow {
   flex-shrink: 0;
   color: var(--text-faint);
-  transition: color var(--transition-fast), transform var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    transform var(--transition-fast);
 }
 .welcome-import-card:hover .welcome-import-card-arrow {
   color: var(--primary);
@@ -1618,6 +1620,118 @@ body {
 }
 
 /* ═══════════════════════════════
+   TOASTS
+═══════════════════════════════ */
+.toast-stack {
+  position: fixed;
+  bottom: 7rem;
+  right: 1.75rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  pointer-events: none;
+  width: 380px;
+}
+.toast {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1rem 1rem 1.1rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-light);
+  border-left-width: 4px;
+  background: var(--white);
+  font-family: var(--font-body);
+  line-height: 1.45;
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.08),
+    0 1px 3px rgba(0, 0, 0, 0.05);
+  pointer-events: all;
+  animation: toast-in 0.22s cubic-bezier(0.34, 1.2, 0.64, 1) both;
+}
+.toast--exit {
+  animation: toast-out 0.18s ease forwards;
+}
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+@keyframes toast-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+}
+.toast--error {
+  border-left-color: var(--error);
+}
+.toast--warning {
+  border-left-color: var(--warning);
+}
+.toast--info {
+  border-left-color: #2563eb;
+}
+.toast-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  margin-top: 1px;
+}
+.toast--error .toast-icon {
+  color: var(--error);
+}
+.toast--warning .toast-icon {
+  color: var(--warning);
+}
+.toast--info .toast-icon {
+  color: #2563eb;
+}
+.toast-body {
+  flex: 1;
+  min-width: 0;
+}
+.toast-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.2rem;
+}
+.toast-message {
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+.toast-close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.2rem;
+  border-radius: 3px;
+  color: var(--text-faint);
+  transition: color var(--transition-fast);
+  margin-top: 0;
+}
+.toast-close:hover {
+  color: var(--text-secondary);
+}
+
+/* ═══════════════════════════════
    FOOTER
 ═══════════════════════════════ */
 .footer-bar {
@@ -1795,7 +1909,9 @@ body {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 }
 
 .alert-dialog-close:hover {
@@ -1861,7 +1977,8 @@ body {
 }
 
 .alert-dialog-hint code {
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 12px;
   background: var(--white);
   padding: 0.05rem 0.35rem;
@@ -1886,7 +2003,9 @@ body {
   font-size: 13.5px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease, transform 0.1s ease;
+  transition:
+    background 0.15s ease,
+    transform 0.1s ease;
   min-width: 110px;
 }
 
@@ -1904,13 +2023,23 @@ body {
 }
 
 @keyframes alertFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes alertPopIn {
-  from { opacity: 0; transform: translateY(12px) scale(0.96); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 /* ═══════════════════════════════
@@ -2430,9 +2559,9 @@ body {
   background: var(--white);
   border-radius: var(--radius-lg);
   box-shadow:
-    0 0 0 1px rgba(133,57,83,0.08),
-    0 8px 32px rgba(17,24,39,0.14),
-    0 2px 8px rgba(17,24,39,0.08);
+    0 0 0 1px rgba(133, 57, 83, 0.08),
+    0 8px 32px rgba(17, 24, 39, 0.14),
+    0 2px 8px rgba(17, 24, 39, 0.08);
   width: 100%;
   max-width: 920px;
   max-height: 92vh;
@@ -2479,7 +2608,9 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
   flex-shrink: 0;
 }
 .cim-close:hover {
@@ -2503,7 +2634,7 @@ body {
   display: flex;
   align-items: center;
   background: var(--primary-faint);
-  border-bottom: 1px solid rgba(133,57,83,0.1);
+  border-bottom: 1px solid rgba(133, 57, 83, 0.1);
   padding: 0.85rem 1.5rem;
   flex-shrink: 0;
   gap: 0;
@@ -2517,7 +2648,7 @@ body {
 .cim-kpi-div {
   width: 1px;
   height: 32px;
-  background: rgba(133,57,83,0.18);
+  background: rgba(133, 57, 83, 0.18);
   flex-shrink: 0;
 }
 
@@ -2679,7 +2810,9 @@ body {
   flex-shrink: 0;
   transition: color var(--transition-fast);
 }
-.rim-close:hover { color: var(--text); }
+.rim-close:hover {
+  color: var(--text);
+}
 
 /* Tabs */
 .rim-tabs {
@@ -2704,7 +2837,10 @@ body {
   cursor: pointer;
   transition: all var(--transition-fast);
 }
-.rim-tab:hover { background: var(--surface); color: var(--text-secondary); }
+.rim-tab:hover {
+  background: var(--surface);
+  color: var(--text-secondary);
+}
 .rim-tab.active {
   background: var(--primary-faint);
   color: var(--primary);
@@ -2741,8 +2877,13 @@ body {
   outline: none;
   transition: border-color var(--transition-fast);
 }
-.rim-textarea:focus { border-color: var(--primary); background: var(--white); }
-.rim-textarea::placeholder { color: var(--text-faint); }
+.rim-textarea:focus {
+  border-color: var(--primary);
+  background: var(--white);
+}
+.rim-textarea::placeholder {
+  color: var(--text-faint);
+}
 
 /* Drop zone */
 .rim-dropzone {
@@ -2763,14 +2904,43 @@ body {
   border-color: var(--primary);
   background: var(--primary-faint);
 }
-.rim-dropzone.has-file { border-style: solid; border-color: var(--primary); background: var(--primary-faint); }
-.rim-drop-icon { color: var(--text-faint); }
-.rim-drop-icon-ok { color: var(--primary); }
-.rim-drop-label { font-size: 13px; color: var(--text-secondary); margin: 0; }
-.rim-drop-link { color: var(--primary); text-decoration: underline; }
-.rim-drop-formats { font-size: 11.5px; color: var(--text-faint); margin: 0; letter-spacing: 0.03em; }
-.rim-drop-filename { font-size: 13px; font-weight: 700; color: var(--primary); margin: 0; }
-.rim-drop-change { font-size: 11.5px; color: var(--text-muted); margin: 0; }
+.rim-dropzone.has-file {
+  border-style: solid;
+  border-color: var(--primary);
+  background: var(--primary-faint);
+}
+.rim-drop-icon {
+  color: var(--text-faint);
+}
+.rim-drop-icon-ok {
+  color: var(--primary);
+}
+.rim-drop-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+.rim-drop-link {
+  color: var(--primary);
+  text-decoration: underline;
+}
+.rim-drop-formats {
+  font-size: 11.5px;
+  color: var(--text-faint);
+  margin: 0;
+  letter-spacing: 0.03em;
+}
+.rim-drop-filename {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--primary);
+  margin: 0;
+}
+.rim-drop-change {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  margin: 0;
+}
 
 .rim-pdf-ready {
   display: flex;
@@ -2810,8 +2980,13 @@ body {
   transition: border-color var(--transition-fast);
   box-sizing: border-box;
 }
-.rim-osf-input:focus { border-color: var(--primary); background: var(--white); }
-.rim-osf-input::placeholder { color: var(--text-faint); }
+.rim-osf-input:focus {
+  border-color: var(--primary);
+  background: var(--white);
+}
+.rim-osf-input::placeholder {
+  color: var(--text-faint);
+}
 .rim-osf-hint {
   font-size: 12px;
   color: var(--text-muted);
@@ -2869,7 +3044,11 @@ body {
   border-radius: 50%;
   animation: rim-spin 0.7s linear infinite;
 }
-@keyframes rim-spin { to { transform: rotate(360deg); } }
+@keyframes rim-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 .rim-progress-text {
   font-size: 14px;
@@ -2907,11 +3086,22 @@ body {
   flex-shrink: 0;
   font-size: 12px;
 }
-.rim-sum-item { font-weight: 700; }
-.rim-sum-found { color: var(--success); }
-.rim-sum-none  { color: var(--text-muted); }
-.rim-sum-sep   { color: var(--border); }
-.rim-sum-hint  { color: var(--text-faint); font-weight: 400; }
+.rim-sum-item {
+  font-weight: 700;
+}
+.rim-sum-found {
+  color: var(--success);
+}
+.rim-sum-none {
+  color: var(--text-muted);
+}
+.rim-sum-sep {
+  color: var(--border);
+}
+.rim-sum-hint {
+  color: var(--text-faint);
+  font-weight: 400;
+}
 
 .rim-results-list {
   flex: 1;
@@ -2929,9 +3119,16 @@ body {
   transition: background var(--transition-fast);
   border-bottom: 1px solid var(--border-light);
 }
-.rim-result-row:last-child { border-bottom: none; }
-.rim-result-row:hover:not(.rim-row-none) { background: var(--surface); }
-.rim-row-none { opacity: 0.55; cursor: default; }
+.rim-result-row:last-child {
+  border-bottom: none;
+}
+.rim-result-row:hover:not(.rim-row-none) {
+  background: var(--surface);
+}
+.rim-row-none {
+  opacity: 0.55;
+  cursor: default;
+}
 
 .rim-row-check {
   flex-shrink: 0;
@@ -2961,7 +3158,10 @@ body {
   color: white;
 }
 
-.rim-row-body { flex: 1; min-width: 0; }
+.rim-row-body {
+  flex: 1;
+  min-width: 0;
+}
 
 .rim-row-top {
   display: flex;
@@ -2980,10 +3180,22 @@ body {
   border-radius: 3px;
   flex-shrink: 0;
 }
-.rim-badge-direct   { background: var(--success-bg); color: var(--success); }
-.rim-badge-crossref { background: var(--primary-faint); color: var(--primary); }
-.rim-badge-openalex { background: var(--warning-bg); color: var(--warning); }
-.rim-badge-none     { background: var(--surface-alt); color: var(--text-muted); }
+.rim-badge-direct {
+  background: var(--success-bg);
+  color: var(--success);
+}
+.rim-badge-crossref {
+  background: var(--primary-faint);
+  color: var(--primary);
+}
+.rim-badge-openalex {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+.rim-badge-none {
+  background: var(--surface-alt);
+  color: var(--text-muted);
+}
 
 .rim-row-doi {
   font-family: "Menlo", "Consolas", monospace;
@@ -3056,7 +3268,10 @@ body {
   cursor: pointer;
   transition: all var(--transition-fast);
 }
-.rim-btn-ghost:hover { background: var(--surface); border-color: var(--border); }
+.rim-btn-ghost:hover {
+  background: var(--surface);
+  border-color: var(--border);
+}
 
 .rim-btn-primary {
   display: flex;
@@ -3073,8 +3288,13 @@ body {
   cursor: pointer;
   transition: background var(--transition-fast);
 }
-.rim-btn-primary:hover:not(:disabled) { background: var(--primary-dark); }
-.rim-btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+.rim-btn-primary:hover:not(:disabled) {
+  background: var(--primary-dark);
+}
+.rim-btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 
 /* Import refs button + search group in TopBar */
 .topbar-search-group {
@@ -3258,9 +3478,15 @@ body {
   color: var(--white);
 }
 
-.adv-bucket-icon--green { background: #16a34a; }
-.adv-bucket-icon--amber { background: #d97706; }
-.adv-bucket-icon--red   { background: #b42318; }
+.adv-bucket-icon--green {
+  background: #16a34a;
+}
+.adv-bucket-icon--amber {
+  background: #d97706;
+}
+.adv-bucket-icon--red {
+  background: #b42318;
+}
 
 .adv-bucket-label {
   font-size: 0.78rem;
@@ -3315,9 +3541,21 @@ body {
   border: 1px solid transparent;
 }
 
-.adv-tag--green { background: #dcfce7; color: #15803d; border-color: #86efac; }
-.adv-tag--amber { background: #fef3c7; color: #92400e; border-color: #fcd34d; }
-.adv-tag--red   { background: #fee2e2; color: #b91c1c; border-color: #fca5a5; }
+.adv-tag--green {
+  background: #dcfce7;
+  color: #15803d;
+  border-color: #86efac;
+}
+.adv-tag--amber {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fcd34d;
+}
+.adv-tag--red {
+  background: #fee2e2;
+  color: #b91c1c;
+  border-color: #fca5a5;
+}
 
 .adv-tag-remove {
   background: none;
@@ -3333,7 +3571,9 @@ body {
   color: inherit;
 }
 
-.adv-tag-remove:hover { opacity: 1; }
+.adv-tag-remove:hover {
+  opacity: 1;
+}
 
 /* ── Filters row ── */
 .adv-filters-row {
@@ -3557,7 +3797,9 @@ body {
   transition: background var(--transition-fast);
 }
 
-.adv-search-btn:hover:not(:disabled) { background: var(--primary-dark); }
+.adv-search-btn:hover:not(:disabled) {
+  background: var(--primary-dark);
+}
 
 .adv-search-btn:disabled {
   opacity: 0.4;
@@ -3642,7 +3884,9 @@ body {
   scrollbar-width: none;
   min-width: 0;
 }
-.topbar-adv-chips::-webkit-scrollbar { display: none; }
+.topbar-adv-chips::-webkit-scrollbar {
+  display: none;
+}
 
 .topbar-adv-chip {
   display: inline-flex;
@@ -3731,7 +3975,9 @@ body {
   scrollbar-width: none;
   min-width: 0;
 }
-.mob-adv-active-chips::-webkit-scrollbar { display: none; }
+.mob-adv-active-chips::-webkit-scrollbar {
+  display: none;
+}
 .mob-adv-edit-btn {
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
Introduce a Toast component and styles, and wire it into App to show user-friendly error toasts. Adds src/components/layout/Toast.tsx (createToastState, ToastStack, auto-dismiss, variants) and CSS for toast layout/animations in index.css. Replaces console.error calls in App.tsx with toast-based feedback using a toastDetails helper that maps HttpError statuses to messages and shows toasts on various fetch failures.