### PR TITLE
Add wildcard help to advanced search

### DIFF
--- a/src/components/layout/AdvancedSearchPanel.tsx
+++ b/src/components/layout/AdvancedSearchPanel.tsx
@@ -435,6 +435,19 @@ export const AdvancedSearchPanel = (props: Props) => {
                     <span>Filter by original, replication, or reproduction</span>
                   </div>
                 </div>
+                <div class="adv-help-wildcards">
+                  <div class="adv-help-wildcards-title">Wildcard patterns</div>
+                  <div class="adv-help-wildcards-grid">
+                    <code>priming</code>
+                    <span>Exact whole word — matches "priming" only</span>
+                    <code>priming?</code>
+                    <span>Optional trailing character — matches "priming" and "primings"</span>
+                    <code>prim*</code>
+                    <span>Starts with — matches "priming", "primary", "primed"…</span>
+                    <code>*prim*</code>
+                    <span>Contains anywhere — matches "repriming", "social priming"…</span>
+                  </div>
+                </div>
                 <p class="adv-help-hint">Press <kbd>Enter</kbd> or <kbd>,</kbd> to commit a keyword.</p>
               </div>
             </Show>

--- a/src/index.css
+++ b/src/index.css
@@ -3711,6 +3711,40 @@ body {
   line-height: 1.6;
 }
 
+.adv-help-wildcards {
+  margin-top: 0.75rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border-light);
+}
+.adv-help-wildcards-title {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+}
+.adv-help-wildcards-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.75rem;
+  align-items: baseline;
+  font-size: 0.78rem;
+}
+.adv-help-wildcards-grid code {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0.05rem 0.35rem;
+  color: #853953;
+  white-space: nowrap;
+}
+.adv-help-wildcards-grid span {
+  color: var(--text-muted);
+}
+
 .adv-modal-close {
   background: none;
   border: none;


### PR DESCRIPTION
Introduce a Wildcard patterns help section in AdvancedSearchPanel with examples (priming, priming?, prim*, *prim*) and brief explanations of their matching behavior. Add corresponding CSS (.adv-help-wildcards, .adv-help-wildcards-title, .adv-help-wildcards-grid and code/span styles) to style the new help grid and inline code tokens.