### PR TITLE
Fix cancel, Escape-edit, and file re-select bugs in ReferenceImportModal

### DIFF
--- a/src/components/layout/ReferenceImportModal.tsx
+++ b/src/components/layout/ReferenceImportModal.tsx
@@ -184,7 +184,9 @@ export const ReferenceImportModal = (props: Props) => {
     setProgress({ done: 0, total: refs.length });
     const found = await lookupAll(
       refs,
-      (done, total) => setProgress({ done, total }),
+      (done, total) => {
+        if (!signal.aborted) setProgress({ done, total });
+      },
       signal,
     );
     if (signal.aborted) return;

--- a/src/components/layout/ReferenceImportModal.tsx
+++ b/src/components/layout/ReferenceImportModal.tsx
@@ -110,8 +110,11 @@ export const ReferenceImportModal = (props: Props) => {
   };
 
   const handleFileInput = (e: Event) => {
-    const file = (e.currentTarget as HTMLInputElement).files?.[0];
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
     if (file) loadFile(file);
+    // Reset so re-selecting the same file still fires a change event
+    input.value = "";
   };
 
   const handleDrop = (e: DragEvent) => {
@@ -149,6 +152,7 @@ export const ReferenceImportModal = (props: Props) => {
         }
         return;
       }
+      if (signal.aborted) return;
       if (refs.length === 0) {
         setStage("input");
         setError("No DOIs found in the OSF content.");
@@ -183,19 +187,32 @@ export const ReferenceImportModal = (props: Props) => {
       (done, total) => setProgress({ done, total }),
       signal,
     );
+    if (signal.aborted) return;
     setResults(found);
     setStage("results");
   };
 
   const [editingIndex, setEditingIndex] = createSignal<number | null>(null);
   const [editingValue, setEditingValue] = createSignal("");
+  // Set when Escape aborts an edit, so the ensuing blur skips committing
+  let editCancelled = false;
 
   const startEdit = (index: number, currentDoi: string) => {
+    editCancelled = false;
     setEditingIndex(index);
     setEditingValue(currentDoi);
   };
 
+  const cancelEdit = () => {
+    editCancelled = true;
+    setEditingIndex(null);
+  };
+
   const commitEdit = (index: number) => {
+    if (editCancelled) {
+      editCancelled = false;
+      return;
+    }
     const doi = editingValue().trim();
     setResults((prev) =>
       prev.map((r, i) => {
@@ -680,7 +697,7 @@ export const ReferenceImportModal = (props: Props) => {
                                 e.preventDefault();
                                 commitEdit(i());
                               }
-                              if (e.key === "Escape") setEditingIndex(null);
+                              if (e.key === "Escape") cancelEdit();
                             }}
                             onBlur={() => commitEdit(i())}
                             onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Fixes

- **Cancel/close during DOI lookup was ignored**: `lookupAll` resolves with partial results after abort, and `runExtraction` unconditionally forced the UI into the results stage. Post-await `signal.aborted` guards now cover both the lookup and the (disabled) OSF path, and the progress callback is abort-guarded so a cancelled lookup's in-flight batch can't overwrite a newer lookup's progress.
- **Escape committed an in-progress DOI edit**: Escape unmounted the edit input, whose blur then ran `commitEdit` with the abandoned value. An `editCancelled` flag now skips that commit; Enter- and click-away-commit unchanged.
- **Re-selecting the same file did nothing**: the file input's value is now reset after handling so choosing the same file re-fires `change`.

Reviewed by codex (read-only pass over the diff); its one finding (unguarded progress callback) is fixed in the second commit. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)