### PR TITLE
Fix outcome display: denominators, unrecognized outcomes, form prefill

### DIFF
--- a/src/api/formatter.ts
+++ b/src/api/formatter.ts
@@ -1,4 +1,5 @@
 import type { OriginalPaper, FormattedDOIResult, DOIResults } from "../@types";
+import { normalizeOutcome } from "../utils/formatter";
 
 export const formatReplicationResponse = (data?: OriginalPaper): FormattedDOIResult => {
     if (!data) {
@@ -8,13 +9,14 @@ export const formatReplicationResponse = (data?: OriginalPaper): FormattedDOIRes
     const replications = data.record?.replications || [];
     const outcomes = replications.reduce(
         (acc, curr) => {
-            if (curr.outcome === "successful") {
+            const outcome = normalizeOutcome(curr.outcome);
+            if (outcome === "successful") {
                 acc.success = (acc.success || 0) + 1;
-            } else if (curr.outcome === "failed") {
+            } else if (outcome === "failed") {
                 acc.failed = (acc.failed || 0) + 1;
-            } else if (curr.outcome === "partial") {
+            } else if (outcome === "partial") {
                 acc.partial = (acc.partial || 0) + 1;
-            } else if (curr.outcome === "mixed") {
+            } else if (outcome === "mixed") {
                 acc.mixed = (acc.mixed || 0) + 1;
             }
             return acc;

--- a/src/components/layout/DetailView.tsx
+++ b/src/components/layout/DetailView.tsx
@@ -183,17 +183,29 @@ export const DetailView = (props: DetailViewProps) => {
   };
 
   const outcomes = () => rep().outcomes;
-  const total = () => outcomes()?.total || 0;
+  // Denominator is the categorized total; `outcomes.total` includes replications
+  // with a null/other outcome that belong to no segment and must not be shown.
+  const categorizedTotal = () => {
+    const o = outcomes();
+    if (!o) return 0;
+    return (o.success || 0) + (o.mixed || 0) + (o.partial || 0) + (o.failed || 0);
+  };
   const successPct = () =>
-    total() > 0 ? Math.round(((outcomes()?.success || 0) / total()) * 100) : 0;
+    categorizedTotal() > 0
+      ? Math.round(((outcomes()?.success || 0) / categorizedTotal()) * 100)
+      : 0;
   const mixedPct = () =>
-    total() > 0
+    categorizedTotal() > 0
       ? Math.round(
-          (((outcomes()?.mixed || 0) + (outcomes()?.partial || 0)) / total()) *
+          (((outcomes()?.mixed || 0) + (outcomes()?.partial || 0)) /
+            categorizedTotal()) *
             100,
         )
       : 0;
-  const failedPct = () => (total() > 0 ? 100 - successPct() - mixedPct() : 0);
+  const failedPct = () =>
+    categorizedTotal() > 0
+      ? Math.round(((outcomes()?.failed || 0) / categorizedTotal()) * 100)
+      : 0;
   const outcomeVariations = () => {
     const o = outcomes();
     if (!o) return 0;

--- a/src/components/layout/DetailView.tsx
+++ b/src/components/layout/DetailView.tsx
@@ -190,21 +190,21 @@ export const DetailView = (props: DetailViewProps) => {
     if (!o) return 0;
     return (o.success || 0) + (o.mixed || 0) + (o.partial || 0) + (o.failed || 0);
   };
+  // Unrounded so the three segment widths always sum to exactly 100%
+  // (independent rounding could yield 99% or 101%); CSS renders fractional %.
   const successPct = () =>
     categorizedTotal() > 0
-      ? Math.round(((outcomes()?.success || 0) / categorizedTotal()) * 100)
+      ? ((outcomes()?.success || 0) / categorizedTotal()) * 100
       : 0;
   const mixedPct = () =>
     categorizedTotal() > 0
-      ? Math.round(
-          (((outcomes()?.mixed || 0) + (outcomes()?.partial || 0)) /
-            categorizedTotal()) *
-            100,
-        )
+      ? (((outcomes()?.mixed || 0) + (outcomes()?.partial || 0)) /
+          categorizedTotal()) *
+        100
       : 0;
   const failedPct = () =>
     categorizedTotal() > 0
-      ? Math.round(((outcomes()?.failed || 0) / categorizedTotal()) * 100)
+      ? ((outcomes()?.failed || 0) / categorizedTotal()) * 100
       : 0;
   const outcomeVariations = () => {
     const o = outcomes();

--- a/src/components/layout/NoDataState.tsx
+++ b/src/components/layout/NoDataState.tsx
@@ -29,7 +29,7 @@ export const NoDataState = (props: NoDataStateProps) => {
           <div class="no-data-actions">
             <a
               class="cb-btn primary"
-              href={`https://docs.google.com/forms/d/e/1FAIpQLSeMCwdtP0TPgL55stniuyyTxnNwyC34mO4VUuLcQwYrLI89sQ/viewform?usp=pp_url&entry.1234567890=${encodeURIComponent(props.doi)}`}
+              href={`https://docs.google.com/forms/d/e/1FAIpQLSeMCwdtP0TPgL55stniuyyTxnNwyC34mO4VUuLcQwYrLI89sQ/viewform?usp=pp_url&entry.355822122=${encodeURIComponent(props.doi)}`}
               target="_blank"
               rel="noreferrer"
             >

--- a/src/components/layout/ReplicationItemCard.tsx
+++ b/src/components/layout/ReplicationItemCard.tsx
@@ -1,6 +1,6 @@
 import { createSignal, For } from "solid-js";
 import type { ReplicationItem } from "../../@types";
-import { authorYearLine } from "../../utils/formatter";
+import { authorYearLine, normalizeOutcome } from "../../utils/formatter";
 
 type ReplicationItemCardProps = {
   item: ReplicationItem;
@@ -23,9 +23,9 @@ function parseOutcomeBadges(outcome: string): BadgeConfig[] {
     "robustness not checked": { label: "Not Checked", cls: "rob-unchecked" },
   };
 
-  // Normalize (trim, lowercase, collapse internal whitespace) so trailing spaces
-  // or irregular spacing don't cause a valid outcome to fall through to "N/A".
-  const normalized = (outcome ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+  // Shared normalization keeps badge matching in lockstep with formatter.ts
+  // bucketing, so a card's badge never contradicts the aggregate counts.
+  const normalized = normalizeOutcome(outcome);
   for (const [compKey, compBadge] of Object.entries(compMap)) {
     for (const [robKey, robBadge] of Object.entries(robMap)) {
       if (normalized === `${compKey}, ${robKey}`) return [compBadge, robBadge];

--- a/src/components/layout/ReplicationItemCard.tsx
+++ b/src/components/layout/ReplicationItemCard.tsx
@@ -23,10 +23,12 @@ function parseOutcomeBadges(outcome: string): BadgeConfig[] {
     "robustness not checked": { label: "Not Checked", cls: "rob-unchecked" },
   };
 
-  const lower = outcome?.toLowerCase() ?? "";
+  // Normalize (trim, lowercase, collapse internal whitespace) so trailing spaces
+  // or irregular spacing don't cause a valid outcome to fall through to "N/A".
+  const normalized = (outcome ?? "").trim().toLowerCase().replace(/\s+/g, " ");
   for (const [compKey, compBadge] of Object.entries(compMap)) {
     for (const [robKey, robBadge] of Object.entries(robMap)) {
-      if (lower === `${compKey}, ${robKey}`) return [compBadge, robBadge];
+      if (normalized === `${compKey}, ${robKey}`) return [compBadge, robBadge];
     }
   }
 
@@ -37,7 +39,11 @@ function parseOutcomeBadges(outcome: string): BadgeConfig[] {
     mixed: { label: "Mixed", cls: "mixed" },
     partial: { label: "Partial", cls: "partial" },
   };
-  return [simple[lower] ?? { label: outcome || "N/A", cls: "" }];
+  if (simple[normalized]) return [simple[normalized]];
+  // A non-empty but unrecognized outcome gets the "other" class so it survives the
+  // hideNa filter; only a truly-empty outcome stays as the class-less "N/A" badge.
+  const trimmed = (outcome ?? "").trim();
+  return [trimmed ? { label: trimmed, cls: "other" } : { label: "N/A", cls: "" }];
 }
 
 const CopyIcon = () => (

--- a/src/components/layout/Toast.tsx
+++ b/src/components/layout/Toast.tsx
@@ -46,14 +46,18 @@ const ICONS: Record<ToastVariant, () => JSX.Element> = {
 
 const ToastItem = (props: ToastItemProps) => {
   const [exiting, setExiting] = createSignal(false);
+  let exitTimer: ReturnType<typeof setTimeout> | undefined;
 
   const dismiss = () => {
     setExiting(true);
-    setTimeout(() => props.onDismiss(props.toast.id), 200);
+    exitTimer = setTimeout(() => props.onDismiss(props.toast.id), 200);
   };
 
   const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
-  onCleanup(() => clearTimeout(timer));
+  onCleanup(() => {
+    clearTimeout(timer);
+    if (exitTimer) clearTimeout(exitTimer);
+  });
 
   return (
     <div

--- a/src/components/replication/SearchOutcomesBanner.tsx
+++ b/src/components/replication/SearchOutcomesBanner.tsx
@@ -27,14 +27,34 @@ const SEGMENTS: Segment[] = [
     { key: "partial", label: "Partial",    color: "var(--primary)"       },
 ];
 
-export const SearchOutcomesBanner = (props: SearchOutcomesBannerProps) => {
-    const segments = createMemo(() =>
-        SEGMENTS.filter(s => props.outcomes[s.key] > 0));
+type DisplaySegment = { label: string; color: string; count: number; pct: number };
 
-    const pct = (key: keyof Omit<OutcomeCounts, "total" | "categorizedTotal">) =>
-        props.outcomes.categorizedTotal > 0
-            ? (props.outcomes[key] / props.outcomes.categorizedTotal) * 100
-            : 0;
+export const SearchOutcomesBanner = (props: SearchOutcomesBannerProps) => {
+    // Widths are relative to `total` (the header count) so the bar always sums to
+    // it; the uncategorized remainder is shown as a muted grey segment.
+    const pct = (count: number) =>
+        props.outcomes.total > 0 ? (count / props.outcomes.total) * 100 : 0;
+
+    const segments = createMemo<DisplaySegment[]>(() => {
+        const shown: DisplaySegment[] = SEGMENTS
+            .filter(s => props.outcomes[s.key] > 0)
+            .map(s => ({
+                label: s.label,
+                color: s.color,
+                count: props.outcomes[s.key],
+                pct: pct(props.outcomes[s.key]),
+            }));
+        const uncategorized = props.outcomes.total - props.outcomes.categorizedTotal;
+        if (uncategorized > 0) {
+            shown.push({
+                label: "Uncategorized",
+                color: "var(--text-muted)",
+                count: uncategorized,
+                pct: pct(uncategorized),
+            });
+        }
+        return shown;
+    });
 
     return (
         <div style={{
@@ -56,11 +76,11 @@ export const SearchOutcomesBanner = (props: SearchOutcomesBannerProps) => {
                 <For each={segments()}>
                     {(s) => (
                         <div
-                            style={{ background: s.color, width: `${pct(s.key)}%`, display: "flex", "align-items": "center", "justify-content": "center" }}
-                            title={`${s.label}: ${props.outcomes[s.key]}`}
+                            style={{ background: s.color, width: `${s.pct}%`, display: "flex", "align-items": "center", "justify-content": "center" }}
+                            title={`${s.label}: ${s.count}`}
                         >
                             <span style={{ color: "white", "font-size": "11px", "font-weight": "700", "text-shadow": "0 1px 2px rgba(0,0,0,0.25)", "user-select": "none" }}>
-                                {props.outcomes[s.key]}
+                                {s.count}
                             </span>
                         </div>
                     )}
@@ -69,7 +89,7 @@ export const SearchOutcomesBanner = (props: SearchOutcomesBannerProps) => {
             <div style={{ display: "flex", width: "100%", gap: "2px", "margin-top": "4px" }}>
                 <For each={segments()}>
                     {(s) => (
-                        <div style={{ width: `${pct(s.key)}%`, "text-align": "center", overflow: "hidden" }}>
+                        <div style={{ width: `${s.pct}%`, "text-align": "center", overflow: "hidden" }}>
                             <span style={{ "font-size": "10px", "font-weight": "600", color: s.color, "white-space": "nowrap" }}>
                                 {s.label}
                             </span>

--- a/src/index.css
+++ b/src/index.css
@@ -1433,6 +1433,10 @@ body {
   background: var(--warning-bg);
   color: #9a6f00;
 }
+.ri-badge.other {
+  background: var(--surface);
+  color: var(--text-muted);
+}
 .ri-badge-group {
   display: flex;
   flex-direction: row;

--- a/src/utils/formatter.tsx
+++ b/src/utils/formatter.tsx
@@ -16,6 +16,20 @@ export const formatAuthors = (authors?: Author[]) => {
 
 export const renderAuthors = (authors?: Author[]) => formatAuthors(authors);
 
+/**
+ * Canonicalize an outcome string for matching/bucketing: trim, lowercase,
+ * collapse internal whitespace, and normalize spacing around commas so variants
+ * like " Successful ", "FAILED", or "computationally successful,robust" compare
+ * equal to their canonical form. Used by both the badge parser and the outcome
+ * counts so cards and aggregate bars never disagree.
+ */
+export const normalizeOutcome = (outcome?: string): string =>
+    (outcome ?? "")
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, " ")
+        .replace(/\s*,\s*/g, ", ");
+
 /** "Authors (Year)" — omitting whichever part is missing; empty string when both are. */
 export const authorYearLine = (authors?: Author[], year?: string | number) => {
     const parts = [formatAuthors(authors), year ? `(${year})` : ""];


### PR DESCRIPTION
## Fixes

- **DetailView outcome bar counted uncategorized replications as "failed"**: `failedPct` was computed as `100 − success − mixed` against a total that includes replications with no/other outcome, rendering them as a red segment. Percentages are now computed against the categorized total, with the failed segment from the actual failed count, and widths are unrounded so segments sum to exactly 100%.
- **SearchOutcomesBanner header and bar used different denominators**: the header said "N Replications" while segments were sized against only the categorized subset. The bar now sums to the header count, with a muted "Uncategorized" segment when some replications have no counted outcome.
- **Unrecognized outcome strings vanished entirely**: exact-string matching meant trailing whitespace or a new outcome vocabulary collapsed to a class-less "N/A" badge that the originals tab then hid. A shared `normalizeOutcome` helper (trim/lowercase/whitespace/comma spacing) is now used by both the badge parser and the outcome bucketing in `api/formatter.ts`, so cards and aggregate bars can never disagree; non-empty unknown outcomes get a visible neutral badge.
- **"Suggest a replication entry" Google Form prefill was a placeholder** (`entry.1234567890`): replaced with the form's real field id for "Reference - Original in APA format with DOI" (`entry.355822122`), verified against the live form.
- **Toast**: the 200 ms exit-animation timer is now cleared on unmount like the auto-dismiss timer.

Reviewed by codex; its two findings (normalization inconsistency between badges and counts, rounding overflow) are fixed in the second commit. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)