### PR TITLE
Fix stale search responses, advanced-search gates, and count mismatches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,6 +171,16 @@ function App() {
   // Monotonic search id; a resolving response is ignored if a newer search started.
   let searchGeneration = 0;
 
+  // Abandon any in-flight search so its (possibly slow) response can't repopulate
+  // state the user has since cleared. Bumping the generation makes both the
+  // success and error handlers of the outstanding request bail.
+  const invalidateSearches = () => {
+    ++searchGeneration;
+    debouncedFuzzySearch.cancel();
+    debouncedDoiSearch.cancel();
+    setIsLoading(false);
+  };
+
   const visibilityMap = new Map<string, number>();
 
   const pickActive = () => {
@@ -267,7 +277,7 @@ function App() {
     setTags(newTags);
     syncUrl(newTags);
     if (newTags.length === 0) {
-      debouncedDoiSearch.cancel();
+      invalidateSearches();
       setResults({});
       setSelectedDoi(null);
       setHasSearched(false);
@@ -315,6 +325,7 @@ function App() {
     if (currentMode === "advanced") {
       clearAdvancedSearch();
     }
+    invalidateSearches();
     setTags([]);
     setResults({});
     setSelectedDoi(null);
@@ -329,6 +340,7 @@ function App() {
       yearFrom: undefined,
       yearTo: undefined,
       outcomes: undefined,
+      paperTypes: undefined,
     });
   };
 
@@ -496,6 +508,10 @@ function App() {
     const advMustAllParam = String(searchParams.mustAll || "");
     const advMustAnyParam = String(searchParams.mustAny || "");
     const advMustNoneParam = String(searchParams.mustNone || "");
+    const advOutcomesParam = String(searchParams.outcomes || "");
+    const advPaperTypesParam = String(searchParams.paperTypes || "");
+    const advYearFromParam = String(searchParams.yearFrom || "");
+    const advYearToParam = String(searchParams.yearTo || "");
     const currentTags = doi
       ? doi
           .split(",")
@@ -521,24 +537,28 @@ function App() {
         setSearchMode("fuzzy");
         doFuzzySearch(q);
       }
-    } else if (advMustAllParam || advMustAnyParam || advMustNoneParam) {
+    } else if (
+      advMustAllParam ||
+      advMustAnyParam ||
+      advMustNoneParam ||
+      advOutcomesParam ||
+      advPaperTypesParam ||
+      advYearFromParam ||
+      advYearToParam
+    ) {
       if (skipAdvancedEffect) {
         skipAdvancedEffect = false;
       } else {
         const mustAll = advMustAllParam ? advMustAllParam.split("|") : [];
         const mustAny = advMustAnyParam ? advMustAnyParam.split("|") : [];
         const mustNone = advMustNoneParam ? advMustNoneParam.split("|") : [];
-        const yearFrom = searchParams.yearFrom
-          ? parseInt(String(searchParams.yearFrom))
-          : 1950;
-        const yearTo = searchParams.yearTo
-          ? parseInt(String(searchParams.yearTo))
+        const yearFrom = advYearFromParam ? parseInt(advYearFromParam) : 1950;
+        const yearTo = advYearToParam
+          ? parseInt(advYearToParam)
           : new Date().getFullYear();
-        const outcomes = searchParams.outcomes
-          ? String(searchParams.outcomes).split("|")
-          : [];
-        const paperTypes = searchParams.paperTypes
-          ? String(searchParams.paperTypes).split("|")
+        const outcomes = advOutcomesParam ? advOutcomesParam.split("|") : [];
+        const paperTypes = advPaperTypesParam
+          ? advPaperTypesParam.split("|")
           : [];
         setAdvMustAll(mustAll);
         setAdvMustAny(mustAny);
@@ -582,6 +602,7 @@ function App() {
       if (ignoreNextReset) {
         ignoreNextReset = false;
       } else {
+        invalidateSearches();
         setTags([]);
         setInputValue("");
         setResults({});
@@ -632,6 +653,7 @@ function App() {
             if (q === "") {
               debouncedFuzzySearch.cancel();
               if (tags().length === 0) {
+                invalidateSearches();
                 setResults({});
                 setSelectedDoi(null);
                 setHasSearched(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,17 @@ import { smoothScrollIntoView } from "./utils/smoothScroll";
 
 const isDoi = (s: string) => /^10\.\d{4,}\//.test(s.trim());
 
+// Shared original/replication classification, kept in sync with StudyListPanel.
+const classifyPaper = (paper: OriginalPaper) => {
+  const rep = formatReplicationResponse(paper);
+  const isOriginal =
+    (rep.replications?.length || 0) > 0 || (rep.reproductions?.length || 0) > 0;
+  const isReplication =
+    (rep.originals?.length || 0) > 0 ||
+    (paper.types?.includes("reproduction") ?? false);
+  return { isOriginal, isReplication };
+};
+
 const debounce = <T extends unknown[]>(
   fn: (...args: T) => void,
   delay: number,
@@ -108,13 +119,7 @@ function App() {
   const filteredResults = createMemo(() => {
     const filter = typeFilter();
     return Object.entries(results()).filter(([, paper]) => {
-      const rep = formatReplicationResponse(paper);
-      const isOriginal =
-        (rep.replications?.length || 0) > 0 ||
-        (rep.reproductions?.length || 0) > 0;
-      const isReplication =
-        (rep.originals?.length || 0) > 0 ||
-        (paper.types?.includes("reproduction") ?? false);
+      const { isOriginal, isReplication } = classifyPaper(paper);
       if (filter === "original") return isOriginal;
       return isReplication;
     });
@@ -126,12 +131,7 @@ function App() {
     const counts = Object.values(res).reduce(
       (acc, paper) => {
         const rep = formatReplicationResponse(paper);
-        const isOriginal =
-          (rep.replications?.length || 0) > 0 ||
-          (rep.reproductions?.length || 0) > 0;
-        const isReplication =
-          (rep.originals?.length || 0) > 0 ||
-          (paper.types?.includes("reproduction") ?? false);
+        const { isOriginal, isReplication } = classifyPaper(paper);
         if (filter === "original" && !isOriginal) return acc;
         if (filter === "replication" && !isReplication) return acc;
         acc.success += rep.outcomes?.success ?? 0;
@@ -153,13 +153,8 @@ function App() {
   const paperCount = createMemo(() => {
     const filter = typeFilter();
     return Object.values(results()).filter((p) => {
-      if (!p.record) return false;
-      const rep = formatReplicationResponse(p);
-      const isOriginal = (rep.replications?.length || 0) > 0;
-      const isReplication = (rep.originals?.length || 0) > 0;
-      if (filter === "original") return isOriginal;
-      if (filter === "replication") return isReplication;
-      return true;
+      const { isOriginal, isReplication } = classifyPaper(p);
+      return filter === "original" ? isOriginal : isReplication;
     }).length;
   });
 
@@ -173,6 +168,8 @@ function App() {
   let skipFuzzyEffect = false;
   let skipDoiEffect = false;
   let skipAdvancedEffect = false;
+  // Monotonic search id; a resolving response is ignored if a newer search started.
+  let searchGeneration = 0;
 
   const visibilityMap = new Map<string, number>();
 
@@ -287,20 +284,8 @@ function App() {
 
     // Auto-switch filter if the current one has no matches
     const papers = Object.values(data);
-    const hasOriginals = papers.some((p) => {
-      const rep = formatReplicationResponse(p);
-      return (
-        (rep.replications?.length || 0) > 0 ||
-        (rep.reproductions?.length || 0) > 0
-      );
-    });
-    const hasReplications = papers.some((p) => {
-      const rep = formatReplicationResponse(p);
-      return (
-        (rep.originals?.length || 0) > 0 ||
-        (p.types?.includes("reproduction") ?? false)
-      );
-    });
+    const hasOriginals = papers.some((p) => classifyPaper(p).isOriginal);
+    const hasReplications = papers.some((p) => classifyPaper(p).isReplication);
     if (typeFilter() === "original" && !hasOriginals && hasReplications) {
       setTypeFilter("replication");
     } else if (
@@ -349,14 +334,19 @@ function App() {
 
   const doDoiSearch = (dois: string[]) => {
     if (dois.length === 0) return;
+    const gen = ++searchGeneration;
     setIsLoading(true);
     setHasSearched(true);
     setHasEverSearched(true);
     setResults({});
     setSelectedDoi(null);
     fetchMultipleDOIInfo(dois)
-      .then(handleResults)
+      .then((res) => {
+        if (gen !== searchGeneration) return;
+        handleResults(res);
+      })
       .catch((error) => {
+        if (gen !== searchGeneration) return;
         setIsLoading(false);
         setResults({});
         const [t, m, r] = toastDetails(error);
@@ -366,6 +356,7 @@ function App() {
 
   const doFuzzySearch = (query: string) => {
     if (!query) return;
+    const gen = ++searchGeneration;
     skipFuzzyEffect = true;
     setIsLoading(true);
     setHasSearched(true);
@@ -374,8 +365,12 @@ function App() {
     setSelectedDoi(null);
     setSearchParams({ q: query, dois: undefined });
     fetchFuzzySearch(query)
-      .then(handleResults)
+      .then((res) => {
+        if (gen !== searchGeneration) return;
+        handleResults(res);
+      })
       .catch((error) => {
+        if (gen !== searchGeneration) return;
         setIsLoading(false);
         setResults({});
         const [t, m, r] = toastDetails(error);
@@ -388,12 +383,22 @@ function App() {
     const mustAny = advMustAny();
     const mustNone = advMustNone();
     const paperTypes = advPaperTypes();
-    if (!mustAll.length && !mustAny.length && !mustNone.length && !paperTypes.length) return;
-
     const yearFrom = advYearFrom();
     const yearTo = advYearTo();
     const outcomes = advOutcomes();
+    const yearNarrowed =
+      yearFrom !== 1950 || yearTo !== new Date().getFullYear();
+    if (
+      !mustAll.length &&
+      !mustAny.length &&
+      !mustNone.length &&
+      !paperTypes.length &&
+      !outcomes.length &&
+      !yearNarrowed
+    )
+      return;
 
+    const gen = ++searchGeneration;
     setShowAdvancedModal(false);
     setSearchMode("advanced");
     skipAdvancedEffect = true;
@@ -428,8 +433,12 @@ function App() {
       outcomes: outcomes.length ? outcomes : undefined,
       paperTypes: paperTypes.length ? paperTypes : undefined,
     })
-      .then(handleResults)
+      .then((res) => {
+        if (gen !== searchGeneration) return;
+        handleResults(res);
+      })
       .catch((error) => {
+        if (gen !== searchGeneration) return;
         setIsLoading(false);
         setResults({});
         const [t, m, r] = toastDetails(error);
@@ -546,6 +555,7 @@ function App() {
         setHasEverSearched(true);
         setResults({});
         setSelectedDoi(null);
+        const gen = ++searchGeneration;
         fetchAdvancedSearch({
           mustHave: mustAll.length ? mustAll : undefined,
           anyOf: mustAny.length ? mustAny : undefined,
@@ -555,8 +565,12 @@ function App() {
           outcomes: outcomes.length ? outcomes : undefined,
           paperTypes: paperTypes.length ? paperTypes : undefined,
         })
-          .then(handleResults)
+          .then((res) => {
+            if (gen !== searchGeneration) return;
+            handleResults(res);
+          })
           .catch((error) => {
+            if (gen !== searchGeneration) return;
             setIsLoading(false);
             setResults({});
             const [t, m] = toastDetails(error);
@@ -579,7 +593,14 @@ function App() {
 
   createEffect(() => {
     hasSearched();
-    setTimeout(() => topbarInputRef?.focus(), 0);
+    const t = setTimeout(() => {
+      // Don't steal focus from another interactive element the user is using.
+      const active = document.activeElement;
+      if (active && active !== document.body && active !== topbarInputRef)
+        return;
+      topbarInputRef?.focus();
+    }, 0);
+    onCleanup(() => clearTimeout(t));
   });
 
   return (

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -47,15 +47,18 @@ export const fetchMultipleDOIInfo = async (dois: string[]): Promise<DOIResults> 
   return merged;
 };
 
+const MAX_PAGES = 50;
+
 export const fetchFuzzySearch = async (query: string): Promise<DOIResults> => {
   const allResults: Record<string, OriginalPaper> = {};
   let offset = 0;
 
-  while (true) {
+  for (let page = 0; page < MAX_PAGES; page++) {
     const response = await backend.get<SearchResponse>(
       `/search?q=${encodeURIComponent(query)}&limit=1000&offset=${offset}`
     );
     const data = response.data;
+    if (Object.keys(data.results ?? {}).length === 0) break;
     Object.assign(allResults, data.results ?? {});
     if (!data.hasMore) break;
     offset += 1000;
@@ -87,9 +90,10 @@ export const fetchAdvancedSearch = async (params: AdvancedSearchParams): Promise
   const allResults: Record<string, OriginalPaper> = {};
   let offset = 0;
 
-  while (true) {
+  for (let page = 0; page < MAX_PAGES; page++) {
     const response = await backend.post<SearchResponse>('/search', { ...baseBody, limit: 1000, offset });
     const data = response.data;
+    if (Object.keys(data.results ?? {}).length === 0) break;
     Object.assign(allResults, data.results ?? {});
     if (!data.hasMore) break;
     offset += 1000;

--- a/src/components/layout/AdvancedSearchPanel.tsx
+++ b/src/components/layout/AdvancedSearchPanel.tsx
@@ -355,7 +355,8 @@ export const AdvancedSearchPanel = (props: Props) => {
 
   const canSearch = () =>
     props.state.mustAll.length > 0 || props.state.mustAny.length > 0 || props.state.mustNone.length > 0 ||
-    props.state.paperTypes.length > 0 ||
+    props.state.paperTypes.length > 0 || props.state.outcomes.length > 0 ||
+    props.state.yearFrom !== MIN_YEAR || props.state.yearTo !== MAX_YEAR ||
     pendingAll().trim().length > 0 || pendingAny().trim().length > 0 || pendingNone().trim().length > 0;
 
   const handleKey = (e: KeyboardEvent) => {


### PR DESCRIPTION
## Fixes

- **Out-of-order search responses clobbered newer results** (the main bug): no search path had cancellation or ordering guards, so a slow multi-page fuzzy search resolving after a newer search overwrote results, loading state, and selection. A `searchGeneration` counter now guards every initiator (`doDoiSearch`, `doFuzzySearch`, `doAdvancedSearch`, and the URL-driven advanced fetch) in both success and error handlers — and every reset/abandon path (removing the last tag, clearing the input, switching search mode, navigating to a param-less URL) invalidates in-flight requests so an abandoned search can't resurrect cleared state.
- **Outcome-only / year-only advanced search was impossible**: the Search button's `canSearch` and App's guard ignored `outcomes` and the year range; both now include them, and the URL-restore effect recognizes advanced URLs containing only `outcomes`/`yearFrom`/`yearTo`/`paperTypes` (previously such URLs fell through to the welcome reset on reload). `handleSearchModeChange` now also clears `paperTypes`.
- **Unbounded pagination**: `fetchFuzzySearch`/`fetchAdvancedSearch` looped `while (true)` on `hasMore`; now capped at 50 pages and terminate on an empty page.
- **Banner paper count disagreed with the list**: `paperCount()` ignored reproduction-type papers and required `p.record`; a shared `classifyPaper` helper now backs `filteredResults`, `paperCount`, `aggregateOutcomes`, and `handleResults`.
- **Focus steal**: the top-bar refocus effect now checks where focus actually is when its timeout fires and cleans up the timeout.

Reviewed by codex in two passes; second-pass findings (reset paths not invalidating in-flight requests; filter-only advanced URLs not restored) fixed in the follow-up commit. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)