### PR TITLE
Harden scroll sync and study-list rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,6 +169,7 @@ function App() {
   let isScrollingFromClick = false;
   let scrollClickTimer: number | undefined;
   let observer: IntersectionObserver | undefined;
+  let disposed = false;
   let ignoreNextReset = false;
   let skipFuzzyEffect = false;
   let skipDoiEffect = false;
@@ -230,32 +231,42 @@ function App() {
     observerRebuildPending = true;
     queueMicrotask(() => {
       observerRebuildPending = false;
+      // The microtask can outlive the component; don't recreate the observer.
+      if (disposed) return;
       setupObserver();
     });
   };
 
-  // A long smooth scroll can outlast a fixed timer, so keep suppressing the
-  // observer until the panel actually stops scrolling. The timer is a fallback
-  // for Safari, which does not fire `scrollend`.
-  const handleScrollEnd = () => {
-    if (!isScrollingFromClick) return;
-    isScrollingFromClick = false;
+  // While a click-driven scroll is in flight, suppress the observer until the
+  // panel goes quiet. Each scroll event resets a short quiet timer; when no
+  // scroll fires for the quiet period the animation has settled. This spans the
+  // instant-jump/smooth-residual gap in smoothScrollIntoView (a stray
+  // `scrollend` mid-gap would otherwise release suppression too early), needs no
+  // `scrollend` support, and has no hard deadline. A no-op when not suppressing.
+  const SCROLL_QUIET_MS = 250;
+  const armScrollQuietTimer = () => {
     if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
+    scrollClickTimer = window.setTimeout(() => {
+      isScrollingFromClick = false;
+    }, SCROLL_QUIET_MS);
+  };
+  const handlePanelScroll = () => {
+    if (!isScrollingFromClick) return;
+    armScrollQuietTimer();
   };
 
   onCleanup(() => {
+    disposed = true;
     if (observer) observer.disconnect();
     if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
-    rightPanelRef?.removeEventListener("scrollend", handleScrollEnd);
+    rightPanelRef?.removeEventListener("scroll", handlePanelScroll);
   });
 
   const scrollToPaper = (doi: string) => {
     setSelectedDoi(doi);
     isScrollingFromClick = true;
-    if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
-    scrollClickTimer = window.setTimeout(() => {
-      isScrollingFromClick = false;
-    }, 1500);
+    // Arm immediately so suppression clears even when no scrolling is needed.
+    armScrollQuietTimer();
     const el = paperRefs[doi];
     if (el && rightPanelRef) {
       smoothScrollIntoView(rightPanelRef, el, { block: "start", residualViewports: 3.5 });
@@ -704,7 +715,7 @@ function App() {
           }}
           ref={(el) => {
             rightPanelRef = el;
-            el.addEventListener("scrollend", handleScrollEnd);
+            el.addEventListener("scroll", handlePanelScroll, { passive: true });
           }}
         >
           <Show

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -211,14 +211,42 @@ function App() {
       { root: rightPanelRef, threshold: [0, 0.1, 0.25, 0.5, 0.75, 1] },
     );
 
-    for (const [, el] of Object.entries(paperRefs)) {
-      if (el) observer.observe(el);
+    for (const [doi, el] of Object.entries(paperRefs)) {
+      // Ref callbacks fire before <For> removes old nodes, so paperRefs can
+      // still hold detached elements — prune them and only observe live ones.
+      if (!el || !el.isConnected) {
+        delete paperRefs[doi];
+        continue;
+      }
+      observer.observe(el);
     }
+  };
+
+  // Every row's ref callback requests a rebuild; coalesce them into one rebuild
+  // per render batch instead of tearing down/reconnecting the observer per row.
+  let observerRebuildPending = false;
+  const scheduleObserverSetup = () => {
+    if (observerRebuildPending) return;
+    observerRebuildPending = true;
+    queueMicrotask(() => {
+      observerRebuildPending = false;
+      setupObserver();
+    });
+  };
+
+  // A long smooth scroll can outlast a fixed timer, so keep suppressing the
+  // observer until the panel actually stops scrolling. The timer is a fallback
+  // for Safari, which does not fire `scrollend`.
+  const handleScrollEnd = () => {
+    if (!isScrollingFromClick) return;
+    isScrollingFromClick = false;
+    if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
   };
 
   onCleanup(() => {
     if (observer) observer.disconnect();
     if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
+    rightPanelRef?.removeEventListener("scrollend", handleScrollEnd);
   });
 
   const scrollToPaper = (doi: string) => {
@@ -227,7 +255,7 @@ function App() {
     if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
     scrollClickTimer = window.setTimeout(() => {
       isScrollingFromClick = false;
-    }, 800);
+    }, 1500);
     const el = paperRefs[doi];
     if (el && rightPanelRef) {
       smoothScrollIntoView(rightPanelRef, el, { block: "start", residualViewports: 3.5 });
@@ -674,7 +702,10 @@ function App() {
           classList={{
             "right-panel--scrollable": Object.keys(results()).length > 0,
           }}
-          ref={rightPanelRef}
+          ref={(el) => {
+            rightPanelRef = el;
+            el.addEventListener("scrollend", handleScrollEnd);
+          }}
         >
           <Show
             when={Object.keys(results()).length > 0}
@@ -803,7 +834,7 @@ function App() {
                     data-doi={doi}
                     ref={(el) => {
                       paperRefs[doi] = el;
-                      setupObserver();
+                      scheduleObserverSetup();
                     }}
                     class={`scroll-paper-section ${selectedDoi() === doi ? "highlighted" : ""}`}
                   >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,6 +167,7 @@ function App() {
   let rightPanelRef: HTMLDivElement | undefined;
   let topbarInputRef: HTMLInputElement | undefined;
   let isScrollingFromClick = false;
+  let clickScrollInterrupted = false;
   let scrollClickTimer: number | undefined;
   let observer: IntersectionObserver | undefined;
   let disposed = false;
@@ -248,11 +249,23 @@ function App() {
     if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
     scrollClickTimer = window.setTimeout(() => {
       isScrollingFromClick = false;
+      // If the user hijacked the click-scroll (wheel/touch), the observer's
+      // visibilityMap moved on while pickActive() was suppressed — reconcile
+      // the selection now. For an uninterrupted click-scroll we must NOT, or a
+      // target clamped near the list end (never reaching the panel top) would
+      // wrongly override the clicked selection.
+      if (clickScrollInterrupted) {
+        clickScrollInterrupted = false;
+        pickActive();
+      }
     }, SCROLL_QUIET_MS);
   };
   const handlePanelScroll = () => {
     if (!isScrollingFromClick) return;
     armScrollQuietTimer();
+  };
+  const handleClickScrollInterrupt = () => {
+    if (isScrollingFromClick) clickScrollInterrupted = true;
   };
 
   onCleanup(() => {
@@ -260,11 +273,14 @@ function App() {
     if (observer) observer.disconnect();
     if (scrollClickTimer) window.clearTimeout(scrollClickTimer);
     rightPanelRef?.removeEventListener("scroll", handlePanelScroll);
+    rightPanelRef?.removeEventListener("wheel", handleClickScrollInterrupt);
+    rightPanelRef?.removeEventListener("touchmove", handleClickScrollInterrupt);
   });
 
   const scrollToPaper = (doi: string) => {
     setSelectedDoi(doi);
     isScrollingFromClick = true;
+    clickScrollInterrupted = false;
     // Arm immediately so suppression clears even when no scrolling is needed.
     armScrollQuietTimer();
     const el = paperRefs[doi];
@@ -716,6 +732,8 @@ function App() {
           ref={(el) => {
             rightPanelRef = el;
             el.addEventListener("scroll", handlePanelScroll, { passive: true });
+            el.addEventListener("wheel", handleClickScrollInterrupt, { passive: true });
+            el.addEventListener("touchmove", handleClickScrollInterrupt, { passive: true });
           }}
         >
           <Show

--- a/src/components/layout/StudyListPanel.tsx
+++ b/src/components/layout/StudyListPanel.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js";
 import type { OriginalPaper, FormattedDOIResult } from "../../@types";
 import { formatReplicationResponse } from "../../api/formatter";
 import { formatAuthors } from "../../utils/formatter";
@@ -59,13 +59,23 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
 
   // Keep the highlighted item visible whenever the selection changes (e.g. as
   // the right panel is scrolled). A single panel-level effect avoids waking one
-  // effect per list item on every selection change.
+  // effect per list item on every selection change. Reading the rendered list
+  // also re-fires the scroll after the list re-renders (type-filter toggle,
+  // deep-link results arriving), once the selected item has mounted.
   createEffect(() => {
+    entries();
     const doi = props.selectedDoi;
     if (!doi || !listRef) return;
     const el = itemRefs[doi];
     if (el) smoothScrollIntoView(listRef, el, { block: "nearest", residualViewports: 2 });
   });
+
+  // The checkbox selection persists across searches, so the header would keep
+  // counting DOIs no longer in the list. Reset it whenever a new result set
+  // arrives (defer so the initial mount doesn't clear a pre-seeded selection).
+  createEffect(
+    on(() => props.results, () => setSelectedDois(new Set<string>()), { defer: true }),
+  );
 
   const toggleSelect = (doi: string, e: MouseEvent) => {
     e.stopPropagation();
@@ -83,7 +93,7 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
 
   const clearSelection = () => setSelectedDois(new Set<string>());
 
-  const allEntries = () =>
+  const allEntries = createMemo(() =>
     Object.entries(props.results)
       .map(([doi, paper]) => {
         const rep = formatReplicationResponse(paper);
@@ -100,13 +110,14 @@ export const StudyListPanel = (props: StudyListPanelProps) => {
       .sort((a, b) => {
         if (a.hasData === b.hasData) return 0;
         return a.hasData ? -1 : 1;
-      });
+      }),
+  );
 
-  const entries = () => {
+  const entries = createMemo(() => {
     const filter = props.typeFilter;
     if (filter === "original") return allEntries().filter((e) => e.isOriginal);
     return allEntries().filter((e) => e.isReplication);
-  };
+  });
 
   const totalCount = () => Object.keys(props.results).length;
   const originalCount = () => allEntries().filter((e) => e.isOriginal).length;

--- a/src/utils/smoothScroll.ts
+++ b/src/utils/smoothScroll.ts
@@ -25,6 +25,10 @@ export function smoothScrollIntoView(
 ): void {
   const { block = "start", residualPx, residualViewports = 1 } = opts;
 
+  // Detached nodes report zeroed rects, which would scroll the container to a
+  // bogus position. Bail out — a re-render will have replaced this element.
+  if (!target.isConnected) return;
+
   // Mobile/tablet layouts make the panels `overflow: visible` and scroll the
   // page instead — the passed container isn't the scroller, so defer to the
   // native behaviour.


### PR DESCRIPTION
## Fixes

Follow-ups to the jump-then-residual scroll sync (#137):

- **Detached-node scrolling**: `smoothScrollIntoView` now bails when the target is no longer in the DOM. `itemRefs`/`paperRefs` keep entries for disposed rows after `<For>` re-renders; scrolling to one computed a zeroed rect and jumped the list to the top.
- **Scroll-to-selected on list re-render**: the StudyListPanel effect only tracked `selectedDoi`, so filter toggles or results mounting after a deep-link selection never scrolled the selected item into view. It now also tracks the rendered entries.
- **Stale checkbox selection**: "N selected" persisted across new searches; the selection now resets when the results change.
- **Redundant formatting**: `allEntries`/`entries` are now memos instead of re-running `formatReplicationResponse` over all papers from every JSX read.
- **Scroll suppression**: the fixed 800 ms timer could be outlasted by long smooth scrolls (selection flicker mid-animation). Replaced with a quiet-period debounce: while a click-driven scroll is in flight, each panel scroll event re-arms a 250 ms timer; suppression ends when the panel goes quiet. If the user interrupts the animation by wheel/touch, the selection is reconciled via `pickActive()` when it settles.
- **IntersectionObserver rebuilds**: each row's ref callback triggered a full observer teardown/rebuild (O(N²) per render); rebuilds are now coalesced per render batch, detached refs are pruned, and a disposed guard prevents a queued rebuild from resurrecting the observer after unmount.

Known residual limitations (pre-existing behavior, unchanged): on responsive layouts where the page scrolls instead of the panel, suppression still expires on a fixed quiet window; heavy rAF throttling in hidden tabs can end suppression early.

Reviewed by codex in two passes; second-pass findings (scrollend racing the two-phase scroll, hard-deadline fallback, missing reconciliation after interrupted scrolls) are fixed in the follow-up commits. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)