### PR TITLE
Add focus trapping, focus restore, and consistent Escape handling to modals

### DIFF
--- a/src/components/layout/AdvancedSearchPanel.tsx
+++ b/src/components/layout/AdvancedSearchPanel.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show, createMemo, onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
+import { createFocusTrap } from "../../utils/modalA11y";
 
 // ── Bucket tag input ─────────────────────────────────────────────────────────
 
@@ -348,6 +349,7 @@ type Props = {
 };
 
 export const AdvancedSearchPanel = (props: Props) => {
+  let modalRef: HTMLDivElement | undefined;
   const [pendingAll, setPendingAll] = createSignal("");
   const [pendingAny, setPendingAny] = createSignal("");
   const [pendingNone, setPendingNone] = createSignal("");
@@ -365,6 +367,8 @@ export const AdvancedSearchPanel = (props: Props) => {
   onMount(() => document.addEventListener("keydown", handleKey));
   onCleanup(() => document.removeEventListener("keydown", handleKey));
 
+  createFocusTrap(() => modalRef, () => props.open);
+
   return (
     <Show when={props.open}>
       <div
@@ -373,6 +377,7 @@ export const AdvancedSearchPanel = (props: Props) => {
         role="presentation"
       >
         <div
+          ref={modalRef}
           class="adv-modal"
           role="dialog"
           aria-modal="true"

--- a/src/components/layout/AlertDialog.tsx
+++ b/src/components/layout/AlertDialog.tsx
@@ -1,4 +1,5 @@
 import { Show, onCleanup, onMount, type JSX } from "solid-js";
+import { createFocusTrap } from "../../utils/modalA11y";
 
 type AlertDialogProps = {
   open: boolean;
@@ -11,12 +12,16 @@ type AlertDialogProps = {
 };
 
 export const AlertDialog = (props: AlertDialogProps) => {
+  let dialogRef: HTMLDivElement | undefined;
+
   const handleKey = (e: KeyboardEvent) => {
     if (e.key === "Escape" && props.open) props.onClose();
   };
 
   onMount(() => window.addEventListener("keydown", handleKey));
   onCleanup(() => window.removeEventListener("keydown", handleKey));
+
+  createFocusTrap(() => dialogRef, () => props.open);
 
   return (
     <Show when={props.open}>
@@ -26,6 +31,7 @@ export const AlertDialog = (props: AlertDialogProps) => {
         role="presentation"
       >
         <div
+          ref={dialogRef}
           class="alert-dialog"
           classList={{
             "alert-dialog-warning": (props.variant ?? "warning") === "warning",

--- a/src/components/layout/BugReportModal.tsx
+++ b/src/components/layout/BugReportModal.tsx
@@ -1,4 +1,5 @@
-import { createSignal } from "solid-js";
+import { createSignal, onCleanup, onMount } from "solid-js";
+import { createFocusTrap } from "../../utils/modalA11y";
 
 type Props = {
   errorTitle: string;
@@ -9,8 +10,18 @@ type Props = {
 const GITHUB_REPO = "forrtproject/flora-replication-atlas";
 
 export const BugReportModal = (props: Props) => {
+  let modalRef: HTMLDivElement | undefined;
   const [description, setDescription] = createSignal(props.errorMessage);
   const [steps, setSteps] = createSignal("");
+
+  const handleKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape") props.onClose();
+  };
+  onMount(() => window.addEventListener("keydown", handleKey));
+  onCleanup(() => window.removeEventListener("keydown", handleKey));
+
+  // Mounted only while open, so the trap is always active for this instance.
+  createFocusTrap(() => modalRef, () => true);
 
   const handleSubmit = () => {
     const title = `Bug: ${props.errorTitle}`;
@@ -39,7 +50,7 @@ export const BugReportModal = (props: Props) => {
 
   return (
     <div class="brm-overlay" onClick={props.onClose}>
-      <div class="brm-box" onClick={(e) => e.stopPropagation()}>
+      <div ref={modalRef} class="brm-box" onClick={(e) => e.stopPropagation()}>
         <div class="brm-header">
           <h2 class="brm-title">Report an Error</h2>
           <button class="brm-close" onClick={props.onClose} aria-label="Close">

--- a/src/components/layout/BugReportModal.tsx
+++ b/src/components/layout/BugReportModal.tsx
@@ -14,11 +14,16 @@ export const BugReportModal = (props: Props) => {
   const [description, setDescription] = createSignal(props.errorMessage);
   const [steps, setSteps] = createSignal("");
 
+  // Capture phase so this topmost modal consumes Escape before the underlying
+  // modals' bubble-phase listeners (document/window) can also close on it.
   const handleKey = (e: KeyboardEvent) => {
-    if (e.key === "Escape") props.onClose();
+    if (e.key !== "Escape") return;
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    props.onClose();
   };
-  onMount(() => window.addEventListener("keydown", handleKey));
-  onCleanup(() => window.removeEventListener("keydown", handleKey));
+  onMount(() => document.addEventListener("keydown", handleKey, true));
+  onCleanup(() => document.removeEventListener("keydown", handleKey, true));
 
   // Mounted only while open, so the trap is always active for this instance.
   createFocusTrap(() => modalRef, () => true);

--- a/src/components/layout/CitationImpactModal.tsx
+++ b/src/components/layout/CitationImpactModal.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, Show, For, onCleanup } from "solid-js";
 import type { OriginalPaper, CitationTimelineEntry } from "../../@types";
+import { createFocusTrap } from "../../utils/modalA11y";
 
 type Props = {
   paper: OriginalPaper;
@@ -351,6 +352,7 @@ const LEGEND = [
 ] as const;
 
 export const CitationImpactModal = (props: Props) => {
+  let modalRef: HTMLDivElement | undefined;
   const handleBackdrop = (e: MouseEvent) => {
     if ((e.target as HTMLElement).classList.contains("cim-backdrop"))
       props.onClose();
@@ -362,6 +364,9 @@ export const CitationImpactModal = (props: Props) => {
     document.addEventListener("keydown", handleKey);
     onCleanup(() => document.removeEventListener("keydown", handleKey));
   });
+
+  // Mounted only while open, so the trap is always active for this instance.
+  createFocusTrap(() => modalRef, () => true);
 
   const tl = () => props.paper.citation_timeline?.entries ?? [];
   const reps = () => props.paper.record?.replications ?? [];
@@ -389,6 +394,7 @@ export const CitationImpactModal = (props: Props) => {
   return (
     <div class="cim-backdrop" onClick={handleBackdrop}>
       <div
+        ref={modalRef}
         class="cim-modal"
         role="dialog"
         aria-modal="true"

--- a/src/components/layout/ReferenceImportModal.tsx
+++ b/src/components/layout/ReferenceImportModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../utils/referenceParser";
 import { fetchOsfDois } from "../../utils/osfFetch";
 import { lookupAll, type LookupResult } from "../../utils/doiLookup";
+import { createFocusTrap } from "../../utils/modalA11y";
 
 type Tab = "paste" | "upload" | "osf";
 type Stage = "input" | "processing" | "results";
@@ -52,6 +53,7 @@ export const ReferenceImportModal = (props: Props) => {
 
   let abortController: AbortController | null = null;
   let fileInputRef: HTMLInputElement | undefined;
+  let modalRef: HTMLDivElement | undefined;
 
   const reset = () => {
     abortController?.abort();
@@ -86,6 +88,8 @@ export const ReferenceImportModal = (props: Props) => {
     window.removeEventListener("keydown", handleKey);
     abortController?.abort();
   });
+
+  createFocusTrap(() => modalRef, () => props.open);
 
   const loadFile = (file: File) => {
     const name = file.name.toLowerCase();
@@ -256,6 +260,7 @@ export const ReferenceImportModal = (props: Props) => {
     <Show when={props.open}>
       <div class="rim-backdrop" onClick={handleClose} role="presentation">
         <div
+          ref={modalRef}
           class="rim-modal"
           onClick={(e) => e.stopPropagation()}
           role="dialog"

--- a/src/utils/modalA11y.ts
+++ b/src/utils/modalA11y.ts
@@ -1,0 +1,72 @@
+import { createEffect, onCleanup } from "solid-js";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const getFocusable = (container: HTMLElement): HTMLElement[] =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+
+/**
+ * Traps Tab focus inside a dialog while it is open, moves initial focus into
+ * the dialog on open, and restores focus to the previously focused element on
+ * close. Dependency-free; wire it once near a component's root with an accessor
+ * for the dialog container and an `open` accessor.
+ */
+export function createFocusTrap(
+  getContainer: () => HTMLElement | undefined,
+  isOpen: () => boolean,
+) {
+  createEffect(() => {
+    if (!isOpen()) return;
+    const container = getContainer();
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // Defer so any `autofocus` element inside the dialog wins; only take over
+    // initial focus if nothing in the dialog has claimed it.
+    queueMicrotask(() => {
+      if (!container.isConnected) return;
+      if (container.contains(document.activeElement)) return;
+      const focusables = getFocusable(container);
+      if (focusables.length > 0) {
+        focusables[0].focus();
+      } else {
+        container.setAttribute("tabindex", "-1");
+        container.focus();
+      }
+    });
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusables = getFocusable(container);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !container.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+
+    onCleanup(() => {
+      container.removeEventListener("keydown", handleKeyDown);
+      if (previouslyFocused && previouslyFocused.isConnected) {
+        previouslyFocused.focus();
+      }
+    });
+  });
+}

--- a/src/utils/modalA11y.ts
+++ b/src/utils/modalA11y.ts
@@ -60,10 +60,13 @@ export function createFocusTrap(
       }
     };
 
-    container.addEventListener("keydown", handleKeyDown);
+    // Listen on document, not the container: dynamic content can unmount the
+    // focused element (dropping focus to <body>), after which a container-scoped
+    // listener would never see the Tab and could not recover focus.
+    document.addEventListener("keydown", handleKeyDown);
 
     onCleanup(() => {
-      container.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keydown", handleKeyDown);
       if (previouslyFocused && previouslyFocused.isConnected) {
         previouslyFocused.focus();
       }


### PR DESCRIPTION
## Changes

- **New shared `createFocusTrap` helper** (`src/utils/modalA11y.ts`): traps Tab/Shift+Tab within the dialog, sets initial focus on open (deferring to any `autofocus` element), restores focus to the triggering element on close, and recovers focus that falls to `<body>` when dialog content changes (e.g. ReferenceImportModal stage transitions). Wired into all five modals: AdvancedSearchPanel, ReferenceImportModal, CitationImpactModal, BugReportModal, AlertDialog. Previously none trapped focus or restored it on close.
- **BugReportModal now closes on Escape** — it was the only modal without a handler. Registered in the capture phase and consuming the event, so an Escape on the (always-topmost) bug report can't also close a modal underneath it.

Reviewed by codex; its two findings (focus escaping the container-scoped listener after dynamic unmounts; stacked-modal Escape double-close) are fixed in the follow-up commit. `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)