### PR TITLE
Prerender DOI pages, generate browse pages & SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,54 +5,157 @@
     <link rel="icon" type="image/png" href="/icon_hub.webp" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#853953" />
-    <title>FLoRA Replication Atlas — Has This Study Been Replicated?</title>
-    <meta name="description" content="Search by DOI, title, or author to instantly check whether a study has been replicated. Browse replication outcomes across psychology and social sciences. Powered by FORRT's Replication Database (FReD)." />
-    <meta name="keywords" content="replication atlas, replication database, has this study been replicated, replication crisis, open science, psychology replication, DOI lookup, FORRT, FReD, reproducibility" />
+    <title>Has this study been replicated? — FLoRA Replication Atlas</title>
+    <meta name="description" content="Look up any study by DOI, title, or author and see every replication and reproduction attempt on record, with the outcome and the passage it was read from. __PAPER_COUNT__+ findings from FORRT." />
     <link rel="canonical" href="https://forrt.org/flora-replication-atlas/" />
+
+    <!-- Nothing paints until this cross-origin POST returns, so pay DNS and TLS up front. -->
+    <link rel="preconnect" href="https://rep-api.forrt.org" crossorigin />
+    <link rel="dns-prefetch" href="https://rep-api.forrt.org" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="FLoRA Replication Atlas — Has This Study Been Replicated?" />
-    <meta property="og:description" content="Search by DOI, title, or author to check replication outcomes across psychology and social sciences. Powered by FORRT." />
+    <meta property="og:title" content="Has this study been replicated? — FLoRA Replication Atlas" />
+    <meta property="og:description" content="Search by DOI, title, or author to check replication outcomes across psychology and the social sciences. Powered by FORRT." />
     <meta property="og:url" content="https://forrt.org/flora-replication-atlas/" />
     <meta property="og:site_name" content="FLoRA Replication Atlas" />
     <meta property="og:image" content="https://forrt.org/flora-replication-atlas/og-banner.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="FLoRA Replication Atlas — Has This Study Been Replicated?" />
+    <meta property="og:image:alt" content="FLoRA Replication Atlas. Has this study been replicated?" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="FLoRA Replication Atlas" />
     <meta name="twitter:description" content="Instantly check if a study has been replicated. Search by DOI, author, or title." />
     <meta name="twitter:image" content="https://forrt.org/flora-replication-atlas/og-banner.png" />
-    <meta name="twitter:image:alt" content="FLoRA Replication Atlas — Has This Study Been Replicated?" />
+    <meta name="twitter:image:alt" content="FLoRA Replication Atlas. Has this study been replicated?" />
 
     <!-- Structured Data -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "WebApplication",
-      "name": "FLoRA Replication Atlas",
-      "description": "Search tool to check whether scientific studies have been replicated. Browse replication outcomes by DOI, title, or author across psychology and social sciences.",
-      "url": "https://forrt.org/flora-replication-atlas/",
-      "applicationCategory": "Science",
-      "operatingSystem": "Web",
-      "provider": {
-        "@type": "Organization",
-        "name": "FORRT — Framework for Open and Reproducible Research Training",
-        "url": "https://forrt.org"
-      },
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "USD"
-      }
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "@id": "https://forrt.org/flora-replication-atlas/#app",
+          "name": "FLoRA Replication Atlas",
+          "description": "Search tool to check whether scientific studies have been replicated. Browse replication outcomes by DOI, title, or author across psychology and the social sciences.",
+          "url": "https://forrt.org/flora-replication-atlas/",
+          "mainEntityOfPage": "https://forrt.org/flora-replication-atlas/",
+          "applicationCategory": "Science",
+          "operatingSystem": "Web",
+          "isPartOf": { "@id": "https://forrt.org/flora-replication-atlas/#dataset" },
+          "provider": {
+            "@type": "Organization",
+            "name": "FORRT: Framework for Open and Reproducible Research Training",
+            "url": "https://forrt.org"
+          },
+          "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": {
+              "@type": "EntryPoint",
+              "urlTemplate": "https://forrt.org/flora-replication-atlas/?q={search_term_string}"
+            },
+            "query-input": "required name=search_term_string"
+          }
+        },
+        {
+          "@type": "Dataset",
+          "@id": "https://forrt.org/flora-replication-atlas/#dataset",
+          "name": "FLoRA: FORRT's Library of Reproduction and Replication Attempts",
+          "alternateName": "FORRT Replication Database (FReD)",
+          "description": "A curated index of __PAPER_COUNT__+ original research findings paired with recorded replication and reproduction attempts, including the outcome recorded for each attempt and the quoted passage it was read from.",
+          "url": "https://forrt.org/flora-replication-atlas/",
+          "mainEntityOfPage": "https://forrt.org/flora-replication-atlas/",
+          "keywords": [
+            "replication",
+            "reproducibility",
+            "open science",
+            "metascience",
+            "psychology"
+          ],
+          "isAccessibleForFree": true,
+          "license": "https://creativecommons.org/licenses/by/4.0/",
+          "temporalCoverage": "1950/..",
+          "creator": {
+            "@type": "Organization",
+            "name": "FORRT: Framework for Open and Reproducible Research Training",
+            "url": "https://forrt.org"
+          },
+          "sameAs": [
+            "https://forrt.org/replication-hub/",
+            "https://forrt.org/flora-explorer/"
+          ],
+          "distribution": {
+            "@type": "DataDownload",
+            "encodingFormat": "application/json",
+            "contentUrl": "https://rep-api.forrt.org/v1/dois"
+          }
+        }
+      ]
     }
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!--ssg-start-->
+      <main class="ssg">
+        <h1>Has this study been replicated?</h1>
+        <p>
+          Search the FLoRA Replication Atlas by DOI, title, or author to see every
+          replication and reproduction attempt on record for a finding, the outcome
+          each one reported, and the passage that outcome was read from.
+        </p>
+
+        <h2>Browse the atlas</h2>
+        <ul>
+          <li><a href="/flora-replication-atlas/browse/">All browse pages</a>: by outcome, decade, and journal.</li>
+          <li><a href="/flora-replication-atlas/browse/outcome/failed/">Failed replications</a> and <a href="/flora-replication-atlas/browse/outcome/successful/">successful replications</a>.</li>
+          <li><a href="https://forrt.org/flora-explorer/">FLoRA Explorer</a>: __PAPER_COUNT__+ original findings paired with replication outcomes, filterable.</li>
+        </ul>
+
+        <h2>What a record shows</h2>
+        <p>
+          For example, Nuttin's 1987 name letter effect study
+          (<a href="/flora-replication-atlas/doi/10.1002/ejsp.2420170402/">10.1002/ejsp.2420170402</a>,
+          <i>European Journal of Social Psychology</i>) has one replication on record:
+          Ziano, Yao, Gao and Feldman (2020, <i>Journal of Experimental Social
+          Psychology</i>), recorded as successful, with the quoted passage the label
+          was read from.
+        </p>
+        <dl>
+          <dt>The original study</dt>
+          <dd>Title, authors, journal, and year, with a copyable APA reference and BibTeX entry.</dd>
+          <dt>Every replication and reproduction on record</dt>
+          <dd>Each attempt carries its own citation and DOI, and links to its own page in the atlas.</dd>
+          <dt>The sentence behind the outcome label</dt>
+          <dd>Where the atlas records an outcome, it also shows the quoted passage it was read from and where in the paper that passage appears.</dd>
+          <dt>Routes out of the atlas</dt>
+          <dd>Publisher DOI links, open-access copies where they exist, and the PubPeer thread for post-publication discussion.</dd>
+        </dl>
+
+        <h2>Where the data comes from</h2>
+        <p>
+          The Replication Atlas is a search layer over FLoRA, FORRT's Library of
+          Reproduction and Replication Attempts, which grows out of the FORRT
+          Replication Database (FReD). It currently covers __PAPER_COUNT__+ original
+          findings paired with replication and reproduction attempts across research
+          disciplines.
+        </p>
+        <p>
+          Coverage is not complete, and it is not meant to be read as a verdict on any
+          single paper. If a replication is missing, or a record looks wrong, sending
+          it in is the fastest way to get it fixed.
+        </p>
+        <p>
+          <a href="https://forrt.org/replication-hub/">FORRT Replication Hub</a> &middot;
+          <a href="https://forrt.org/flora-explorer/">FLoRA Explorer</a>
+        </p>
+      </main>
+      <!--ssg-end-->
+    </div>
     <!-- GitHub Pages SPA redirect restore -->
     <script>
       (function () {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build && npm run copy-index2 && npm run generate-sitemap && npm run prerender-doi-pages",
+    "build": "tsc -b && vite build && npm run copy-index2 && npm run prerender-doi-pages && npm run generate-sitemap",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "prerender-doi-pages": "node scripts/prerender-doi-pages.js",
     "build:gh-pages": "BUILD_ENV=gh-pages && npm run build",

--- a/scripts/browse-pages.js
+++ b/scripts/browse-pages.js
@@ -1,0 +1,390 @@
+/**
+ * Static browse pages: the layer between the homepage and the DOI leaves.
+ *
+ * These are plain documents, not SPA routes. The client router has no /browse/*
+ * route, so a hydrated shell would render blank there; GitHub Pages serves these
+ * files directly and they need no JavaScript at all.
+ */
+
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { SITE_URL, cleanTitle, outcomeCounts, shortAuthors, truncateWords } from "../src/seo/pageMeta.js";
+
+const PER_PAGE = 100;
+const MIN_JOURNAL_RECORDS = 3;
+const MAX_JOURNALS = 300;
+
+const OUTCOME_LABELS = {
+  successful: "Successful replications",
+  failed: "Failed replications",
+  mixed: "Mixed replication outcomes",
+  partial: "Partial replication outcomes",
+  unrecorded: "Replications with no recorded outcome",
+  none: "Studies with no replication on record",
+};
+
+const OUTCOME_BLURBS = {
+  successful: "Findings whose every recorded replication or reproduction attempt was read as successful.",
+  failed: "Findings whose every recorded replication or reproduction attempt was read as failed.",
+  mixed: "Findings where recorded attempts disagree, or where an attempt was itself read as mixed.",
+  partial: "Findings whose recorded attempts were read as partial.",
+  unrecorded: "Findings with an attempt on record whose outcome was never labelled.",
+  none: "Findings indexed in the atlas that no replication or reproduction has yet been paired with. An absent record is not evidence a finding failed to replicate.",
+};
+
+function esc(str) {
+  return String(str ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function slugify(text) {
+  return String(text ?? "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+/** The single outcome bucket a study as a whole belongs in. */
+function studyFacet(paper) {
+  const counts = outcomeCounts(paper);
+  if (counts.length === 0) return "none";
+  const named = counts.filter(([b]) => b !== "unrecorded");
+  if (named.length === 0) return "unrecorded";
+  if (named.length > 1) return "mixed";
+  return named[0][0];
+}
+
+function decadeOf(paper) {
+  const year = Number(paper?.year);
+  if (!Number.isFinite(year) || year < 1800 || year > 2100) return null;
+  return `${Math.floor(year / 10) * 10}s`;
+}
+
+/** Group papers into { key -> { label, blurb, path, papers[] } } per facet. */
+function buildFacets(papers) {
+  const outcome = new Map();
+  const decade = new Map();
+  const journal = new Map();
+
+  for (const paper of papers) {
+    const facet = studyFacet(paper);
+    if (!outcome.has(facet))
+      outcome.set(facet, {
+        label: OUTCOME_LABELS[facet],
+        blurb: OUTCOME_BLURBS[facet],
+        path: `browse/outcome/${facet}`,
+        papers: [],
+      });
+    outcome.get(facet).papers.push(paper);
+
+    const dec = decadeOf(paper);
+    if (dec) {
+      if (!decade.has(dec))
+        decade.set(dec, {
+          label: `Studies published in the ${dec}`,
+          blurb: `Original findings first published between ${dec.slice(0, 4)} and ${Number(dec.slice(0, 4)) + 9}, with every replication and reproduction attempt the atlas holds for them.`,
+          path: `browse/year/${dec}`,
+          papers: [],
+          sort: Number(dec.slice(0, 4)),
+        });
+      decade.get(dec).papers.push(paper);
+    }
+
+    const name = (paper?.journal || "").trim();
+    const slug = slugify(name);
+    if (name && slug) {
+      if (!journal.has(slug))
+        journal.set(slug, {
+          label: name,
+          blurb: `Findings first published in ${name}, paired with the replication and reproduction attempts on record.`,
+          path: `browse/journal/${slug}`,
+          papers: [],
+        });
+      journal.get(slug).papers.push(paper);
+    }
+  }
+
+  // A journal with one or two records is a page of chrome; drop it.
+  const journals = [...journal.entries()]
+    .filter(([, g]) => g.papers.length >= MIN_JOURNAL_RECORDS)
+    .sort((a, b) => b[1].papers.length - a[1].papers.length)
+    .slice(0, MAX_JOURNALS);
+
+  const outcomeOrder = ["successful", "failed", "mixed", "partial", "unrecorded", "none"];
+  return {
+    outcome: outcomeOrder.filter((k) => outcome.has(k)).map((k) => outcome.get(k)),
+    decade: [...decade.values()].sort((a, b) => b.sort - a.sort),
+    journal: journals.map(([, g]) => g),
+  };
+}
+
+function studyLine(paper) {
+  const title = cleanTitle(paper.title) || paper.doi;
+  const byline = [shortAuthors(paper.authors), paper.year].filter(Boolean).join(", ");
+  const counts = outcomeCounts(paper);
+  const total = counts.reduce((n, [, c]) => n + c, 0);
+  const outcome =
+    total === 0
+      ? "no replication on record"
+      : counts.map(([b, n]) => `${n} ${b === "unrecorded" ? "unlabelled" : b}`).join(", ");
+  return `<li>
+        <a href="${SITE_URL}/doi/${esc(paper.doi)}/">${esc(truncateWords(title, 130))}</a>
+        <span class="bp-meta">${esc(byline)}${byline ? " — " : ""}${esc(outcome)}</span>
+      </li>`;
+}
+
+const STYLE = `
+    :root{--ink:#2c2c2c;--muted:#5f5f5f;--brand:#853953;--brand-dark:#612d53;--rule:#e6e0e2}
+    *{box-sizing:border-box}
+    body{margin:0;background:#fff;color:var(--ink);font:16px/1.6 "Source Sans 3",system-ui,-apple-system,sans-serif}
+    .bp{max-width:52rem;margin:0 auto;padding:2rem 1.25rem 4rem}
+    h1,h2{font-family:Domine,Georgia,serif;color:var(--brand-dark);line-height:1.25}
+    h1{font-size:1.85rem;margin:.5rem 0}
+    h2{font-size:1.2rem;margin:2rem 0 .5rem}
+    a{color:var(--brand)}
+    nav.bp-crumbs{font-size:.9rem;color:var(--muted);margin-bottom:1rem}
+    p.bp-lede{color:var(--muted);margin:.25rem 0 1.5rem}
+    ul.bp-list{list-style:none;padding:0;margin:0}
+    ul.bp-list li{padding:.6rem 0;border-bottom:1px solid var(--rule)}
+    .bp-meta{display:block;color:var(--muted);font-size:.88rem}
+    .bp-cols{columns:2 16rem;column-gap:2rem}
+    .bp-cols li{break-inside:avoid;margin-bottom:.35rem}
+    .bp-pager{display:flex;flex-wrap:wrap;gap:.75rem;margin-top:2rem;font-size:.95rem}
+    footer.bp-foot{margin-top:3rem;padding-top:1rem;border-top:1px solid var(--rule);font-size:.9rem;color:var(--muted)}
+`;
+
+function document_({ title, description, canonical, crumbs, body, prev, next }) {
+  const links = [
+    `<link rel="canonical" href="${esc(canonical)}" />`,
+    prev ? `<link rel="prev" href="${esc(prev)}" />` : "",
+    next ? `<link rel="next" href="${esc(next)}" />` : "",
+  ].filter(Boolean);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#853953" />
+    <title>${esc(title)}</title>
+    <meta name="description" content="${esc(description)}" />
+    ${links.join("\n    ")}
+    <link rel="icon" type="image/png" href="${SITE_URL}/icon_hub.webp" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="${esc(title)}" />
+    <meta property="og:description" content="${esc(description)}" />
+    <meta property="og:url" content="${esc(canonical)}" />
+    <meta property="og:image" content="${SITE_URL}/og-banner.png" />
+    <style>${STYLE}</style>
+    <script type="application/ld+json">
+    ${JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "@id": canonical,
+      name: title,
+      description,
+      url: canonical,
+      isPartOf: { "@id": `${SITE_URL}/#dataset` },
+      breadcrumb: {
+        "@type": "BreadcrumbList",
+        itemListElement: crumbs.map((c, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          name: c.name,
+          item: c.url,
+        })),
+      },
+    })}
+    </script>
+  </head>
+  <body>
+    <div class="bp">
+      <nav class="bp-crumbs">${crumbs
+        .map((c, i) =>
+          i === crumbs.length - 1
+            ? esc(c.name)
+            : `<a href="${esc(c.url)}">${esc(c.name)}</a>`,
+        )
+        .join(" &rsaquo; ")}</nav>
+      ${body}
+      <footer class="bp-foot">
+        <a href="${SITE_URL}/">Search the FLoRA Replication Atlas</a> &middot;
+        <a href="${SITE_URL}/browse/">Browse all</a> &middot;
+        <a href="https://forrt.org/replication-hub/">FORRT Replication Hub</a>
+      </footer>
+    </div>
+  </body>
+</html>
+`;
+}
+
+function pageUrl(path, page) {
+  return page === 1 ? `${SITE_URL}/${path}/` : `${SITE_URL}/${path}/page/${page}/`;
+}
+
+function pager(path, page, pageCount) {
+  if (pageCount <= 1) return "";
+  const parts = [];
+  if (page > 1) parts.push(`<a href="${pageUrl(path, page - 1)}">&larr; Previous</a>`);
+  parts.push(`<span>Page ${page} of ${pageCount}</span>`);
+  if (page < pageCount) parts.push(`<a href="${pageUrl(path, page + 1)}">Next &rarr;</a>`);
+  return `<div class="bp-pager">${parts.join("")}</div>`;
+}
+
+async function writePage(distDir, path, html) {
+  const outDir = join(distDir, path);
+  await mkdir(outDir, { recursive: true });
+  await writeFile(join(outDir, "index.html"), html, "utf-8");
+}
+
+async function writeFacetGroup(distDir, group, parentCrumbs, urls) {
+  const sorted = [...group.papers].sort(
+    (a, b) => (Number(b.year) || 0) - (Number(a.year) || 0),
+  );
+  const pageCount = Math.max(1, Math.ceil(sorted.length / PER_PAGE));
+
+  for (let page = 1; page <= pageCount; page++) {
+    const slice = sorted.slice((page - 1) * PER_PAGE, page * PER_PAGE);
+    const canonical = pageUrl(group.path, page);
+    const suffix = page > 1 ? ` (page ${page} of ${pageCount})` : "";
+    const title = `${group.label}${suffix} — FLoRA Replication Atlas`;
+    const description = truncateWords(
+      `${sorted.length} studies. ${group.blurb}`,
+      158,
+    );
+
+    const body = `<h1>${esc(group.label)}</h1>
+      <p class="bp-lede">${esc(group.blurb)} ${sorted.length} ${sorted.length === 1 ? "study" : "studies"} in the atlas.</p>
+      <ul class="bp-list">
+        ${slice.map(studyLine).join("\n        ")}
+      </ul>
+      ${pager(group.path, page, pageCount)}`;
+
+    await writePage(
+      distDir,
+      page === 1 ? group.path : `${group.path}/page/${page}`,
+      document_({
+        title,
+        description,
+        canonical,
+        crumbs: [...parentCrumbs, { name: group.label, url: pageUrl(group.path, 1) }],
+        body,
+        prev: page > 1 ? pageUrl(group.path, page - 1) : null,
+        next: page < pageCount ? pageUrl(group.path, page + 1) : null,
+      }),
+    );
+    urls.push(canonical);
+  }
+}
+
+async function writeIndex(distDir, { path, label, blurb, groups, crumbs }, urls) {
+  const canonical = `${SITE_URL}/${path}/`;
+  const body = `<h1>${esc(label)}</h1>
+      <p class="bp-lede">${esc(blurb)}</p>
+      <ul class="bp-list bp-cols">
+        ${groups
+          .map(
+            (g) =>
+              `<li><a href="${SITE_URL}/${g.path}/">${esc(g.label)}</a> <span class="bp-meta">${g.papers.length} ${g.papers.length === 1 ? "study" : "studies"}</span></li>`,
+          )
+          .join("\n        ")}
+      </ul>`;
+  await writePage(
+    distDir,
+    path,
+    document_({
+      title: `${label} — FLoRA Replication Atlas`,
+      description: truncateWords(blurb, 158),
+      canonical,
+      crumbs: [...crumbs, { name: label, url: canonical }],
+      body,
+    }),
+  );
+  urls.push(canonical);
+}
+
+/**
+ * Writes /browse/ and every facet page under it.
+ * @returns {Promise<string[]>} every canonical URL written, for the sitemap.
+ */
+export async function generateBrowsePages(distDir, papers) {
+  const facets = buildFacets(papers);
+  const urls = [];
+  const root = { name: "FLoRA Replication Atlas", url: `${SITE_URL}/` };
+  const hub = { name: "Browse", url: `${SITE_URL}/browse/` };
+
+  const sections = [
+    {
+      path: "browse/outcome",
+      label: "Browse by replication outcome",
+      blurb:
+        "Every study in the atlas, grouped by what its recorded replication and reproduction attempts found.",
+      groups: facets.outcome,
+    },
+    {
+      path: "browse/year",
+      label: "Browse by decade of publication",
+      blurb:
+        "Every study in the atlas, grouped by the decade the original finding was published in.",
+      groups: facets.decade,
+    },
+    {
+      path: "browse/journal",
+      label: "Browse by journal",
+      blurb: `Journals with at least ${MIN_JOURNAL_RECORDS} findings in the atlas, most-covered first.`,
+      groups: facets.journal,
+    },
+  ];
+
+  for (const section of sections) {
+    await writeIndex(distDir, { ...section, crumbs: [root, hub] }, urls);
+    for (const group of section.groups) {
+      await writeFacetGroup(
+        distDir,
+        group,
+        [root, hub, { name: section.label, url: `${SITE_URL}/${section.path}/` }],
+        urls,
+      );
+    }
+  }
+
+  const hubBody = `<h1>Browse the FLoRA Replication Atlas</h1>
+      <p class="bp-lede">${papers.length.toLocaleString("en-US")} original findings, each paired with the replication and reproduction attempts on record for it.</p>
+      ${sections
+        .map(
+          (s) => `<h2><a href="${SITE_URL}/${s.path}/">${esc(s.label)}</a></h2>
+      <p class="bp-lede">${esc(s.blurb)}</p>
+      <ul class="bp-list bp-cols">
+        ${s.groups
+          .slice(0, 24)
+          .map(
+            (g) =>
+              `<li><a href="${SITE_URL}/${g.path}/">${esc(g.label)}</a> <span class="bp-meta">${g.papers.length}</span></li>`,
+          )
+          .join("\n        ")}
+      </ul>`,
+        )
+        .join("\n      ")}`;
+
+  await writePage(
+    distDir,
+    "browse",
+    document_({
+      title: "Browse replication outcomes — FLoRA Replication Atlas",
+      description:
+        "Browse every study in the FLoRA Replication Atlas by replication outcome, decade of publication, or journal.",
+      canonical: `${SITE_URL}/browse/`,
+      crumbs: [root, hub],
+      body: hubBody,
+    }),
+  );
+  urls.push(`${SITE_URL}/browse/`);
+
+  return urls;
+}

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,4 +1,5 @@
 import { writeFile, readFile } from "fs/promises";
+import { dirname, join } from "path";
 
 // const API_BASE = process.env.VITE_BACKEND_URL || "https://rep-api.forrt.org/v1";
 const API_BASE = "https://rep-api.forrt.org/v1/";
@@ -22,14 +23,30 @@ async function fetchAllDois() {
 }
 
 function encodeDoi(doi) {
-  // Percent-encode characters that are invalid in XML (and in URLs)
-  return doi
-    .replace(/&/g, "%26")
-    .replace(/</g, "%3C")
-    .replace(/>/g, "%3E");
+  // Brackets are the common case: emitted raw, the entry is rejected.
+  return doi.replace(
+    /[&<>"'\[\]{}|\\^`\s]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`,
+  );
 }
 
-function buildSitemap(dois) {
+/** Some records store a source URL in the DOI field; those have no page. */
+function isRealDoi(doi) {
+  return typeof doi === "string" && /^10\./.test(doi);
+}
+
+/** Browse-page URLs, written by the prerenderer. Absent on a pre-build run. */
+async function readBrowseUrls() {
+  try {
+    const path = join(dirname(OUTPUT_PATH), "browse-index.json");
+    const urls = JSON.parse(await readFile(path, "utf-8"));
+    return Array.isArray(urls) ? urls : [];
+  } catch {
+    return [];
+  }
+}
+
+function buildSitemap(dois, browseUrls) {
   const today = new Date().toISOString().split("T")[0];
 
   const urls = [
@@ -39,6 +56,16 @@ function buildSitemap(dois) {
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>`,
+    // Browse pages: the layer between the homepage and the DOI leaves
+    ...browseUrls.map(
+      (url) =>
+        `  <url>
+    <loc>${url}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>`,
+    ),
     // DOI pages
     ...dois.map(
       (doi) =>
@@ -60,12 +87,22 @@ ${urls.join("\n")}
 
 async function main() {
   console.log(`Fetching DOIs from ${API_BASE}/dois ...`);
-  const dois = await fetchAllDois();
-  console.log(`Found ${dois.length} DOIs`);
+  const all = await fetchAllDois();
+  const dois = all.filter(isRealDoi);
+  const skipped = all.length - dois.length;
+  console.log(
+    `Found ${all.length} DOIs${skipped ? `, skipping ${skipped} malformed` : ""}`,
+  );
 
-  const xml = buildSitemap(dois);
+  const browseUrls = await readBrowseUrls();
+  if (browseUrls.length)
+    console.log(`Including ${browseUrls.length} browse pages`);
+
+  const xml = buildSitemap(dois, browseUrls);
   await writeFile(OUTPUT_PATH, xml, "utf-8");
-  console.log(`Sitemap written to ${OUTPUT_PATH} (${dois.length + 1} URLs)`);
+  console.log(
+    `Sitemap written to ${OUTPUT_PATH} (${dois.length + browseUrls.length + 1} URLs)`,
+  );
 }
 
 main().catch((err) => {

--- a/scripts/prerender-doi-pages.js
+++ b/scripts/prerender-doi-pages.js
@@ -2,11 +2,19 @@ import { writeFile, readFile, mkdir } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { Resvg } from "@resvg/resvg-js";
+import {
+  SITE_URL,
+  buildDescription,
+  buildTitle,
+  cleanAuthorName,
+  cleanTitle,
+  outcomeCounts,
+} from "../src/seo/pageMeta.js";
+import { generateBrowsePages } from "./browse-pages.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DIST_DIR = join(__dirname, "../dist");
 const API_BASE = "https://rep-api.forrt.org/v1";
-const SITE_URL = "https://forrt.org/flora-replication-atlas";
 const BATCH_SIZE = 100;
 const CONCURRENT_BATCHES = 5;
 
@@ -59,147 +67,245 @@ async function fetchAllPapers(dois) {
 }
 
 function formatAuthors(authors) {
-  if (!Array.isArray(authors) || !authors.length) return "unknown authors";
-  if (authors.length === 1) return authors[0].family;
-  if (authors.length === 2)
-    return `${authors[0].family} & ${authors[1].family}`;
-  return `${authors[0].family} et al.`;
+  const names = (Array.isArray(authors) ? authors : [])
+    .map((a) => cleanAuthorName(a?.family))
+    .filter(Boolean);
+  if (!names.length) return "unknown authors";
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names[0]} et al.`;
 }
 
-function buildPageMeta(paper) {
+/** Sibling atlas page for a linked study, or null when it has none. */
+function atlasHref(doi, atlasDois) {
+  if (!doi || !atlasDois.has(doi)) return null;
+  return `${SITE_URL}/doi/${doi}/`;
+}
+
+function buildPageMeta(paper, atlasDois) {
   const doi = paper.doi;
-  const title = paper.title || doi;
+  const title = cleanTitle(paper.title) || doi;
   const authors = Array.isArray(paper.authors) ? paper.authors : [];
-  const authorNames = authors.map((a) => `${a.family}, ${a.given}`).join("; ");
-  const authorLastNames = authors.map((a) => a.family).filter(Boolean);
 
   const replications = paper.record?.replications || [];
   const reproductions = paper.record?.reproductions || [];
-  const stats = paper.record?.stats;
-  const nReplications = stats?.n_replications_total ?? 0;
-  const nReproductions = stats?.n_reproductions_total ?? 0;
 
-  const allOutcomes = [
-    ...replications.map((r) => r.outcome),
-    ...reproductions.map((r) => r.outcome),
-  ].filter(Boolean);
-  const uniqueOutcomes = [...new Set(allOutcomes)];
+  const pageTitle = buildTitle(paper);
+  const description = buildDescription(paper);
 
-  const replicationSentences = replications.map((r) => {
-    const by = formatAuthors(r.authors);
-    const outcome = r.outcome
-      ? `described as ${r.outcome}`
-      : "outcome not recorded";
-    return `"${title}" has been replicated by ${by} (${r.year}), ${outcome}.`;
-  });
+  const uniqueOutcomes = [
+    ...new Set(
+      [...replications, ...reproductions].map((r) => r.outcome).filter(Boolean),
+    ),
+  ];
 
-  const reproductionSentences = reproductions.map((r) => {
-    const by = formatAuthors(r.authors);
-    const outcome = r.outcome
-      ? `described as ${r.outcome}`
-      : "outcome not recorded";
-    return `"${title}" has been reproduced by ${by} (${r.year}), ${outcome}.`;
-  });
-
-  const replicationSummary =
-    replicationSentences.length > 0 || reproductionSentences.length > 0
-      ? [...replicationSentences, ...reproductionSentences].join(" ")
-      : "No replications or reproductions recorded yet.";
-
-  const description =
-    `"${title}" by ${authorNames} (${paper.year}${paper.journal ? `, ${paper.journal}` : ""}). ` +
-    `${replicationSummary} Indexed in the FLoRA Replication Atlas (FORRT FLoRA database). DOI: ${doi}`;
-
-  const titleKeywords = title
-    .split(/\s+/)
-    .filter((w) => w.length > 4)
-    .slice(0, 6)
-    .map((w) => w.replace(/[^a-zA-Z0-9]/g, ""))
-    .filter(Boolean);
-
+  // JSON-LD only; the `keywords` meta tag is gone.
   const keywords = [
-    ...authorLastNames,
+    ...authors.map((a) => cleanAuthorName(a.family)).filter(Boolean),
     paper.journal,
     String(paper.year),
     ...uniqueOutcomes.map((o) => `${o} replication`),
-    ...titleKeywords,
     "replication",
     "reproducibility",
     "open science",
-    "FLoRA",
-    "FReD",
-    "FORRT",
-    "replication crisis",
-    "has this study been replicated",
-  ]
-    .filter(Boolean)
-    .join(", ");
+  ].filter(Boolean);
 
   // Trailing slash is required: pages are written as doi/<doi>/index.html, and
   // GitHub Pages 301-redirects the slash-less URL to this one. Declaring the
   // slash-less form as canonical makes Google override it with the redirect target.
   const pageUrl = `${SITE_URL}/doi/${doi}/`;
 
-  const jsonLd = JSON.stringify({
-    "@context": "https://schema.org",
+  const attempt = (r, kind) => {
+    const href = atlasHref(r.doi, atlasDois);
+    return {
+      "@type": "ScholarlyArticle",
+      name: cleanTitle(r.title) || r.doi,
+      // A bare string here is not a type; schema.org wants a resolvable URI.
+      additionalType: `https://forrt.org/flora-replication-atlas/#${kind}`,
+      ...(href && { url: href, mainEntityOfPage: href }),
+      ...(r.outcome && { description: `Outcome: ${r.outcome}` }),
+      ...(r.year && { datePublished: String(r.year) }),
+      ...(r.doi && {
+        identifier: {
+          "@type": "PropertyValue",
+          propertyID: "DOI",
+          value: r.doi,
+        },
+        sameAs: `https://doi.org/${r.doi}`,
+      }),
+    };
+  };
+
+  const subjectOf = [
+    ...replications.map((r) => attempt(r, "ReplicationStudy")),
+    ...reproductions.map((r) => attempt(r, "ReproductionStudy")),
+  ];
+
+  const article = {
     "@type": "ScholarlyArticle",
+    "@id": `${pageUrl}#article`,
+    mainEntityOfPage: pageUrl,
     name: title,
-    author: authors.map((a) => ({
-      "@type": "Person",
-      givenName: a.given,
-      familyName: a.family,
-    })),
+    headline: title,
+    author: authors
+      .map((a) => ({
+        "@type": "Person",
+        givenName: cleanAuthorName(a.given) || undefined,
+        familyName: cleanAuthorName(a.family) || undefined,
+        name: cleanAuthorName([a.given, a.family].filter(Boolean).join(" ")),
+      }))
+      .filter((a) => a.name),
     datePublished: String(paper.year),
     isPartOf: paper.journal
       ? { "@type": "Periodical", name: paper.journal }
       : undefined,
     identifier: { "@type": "PropertyValue", propertyID: "DOI", value: doi },
-    url: `https://doi.org/${doi}`,
+    url: pageUrl,
+    sameAs: `https://doi.org/${doi}`,
     description,
     keywords,
-    subjectOf:
-      nReplications > 0 || nReproductions > 0
-        ? [
-            ...replications.map((r) => ({
-              "@type": "ScholarlyArticle",
-              name: r.title,
-              additionalType: "ReplicationStudy",
-              ...(r.outcome && { description: `Outcome: ${r.outcome}` }),
-              ...(r.doi && {
-                identifier: {
-                  "@type": "PropertyValue",
-                  propertyID: "DOI",
-                  value: r.doi,
-                },
-              }),
-            })),
-            ...reproductions.map((r) => ({
-              "@type": "ScholarlyArticle",
-              name: r.title,
-              additionalType: "ReproductionStudy",
-              ...(r.outcome && { description: `Outcome: ${r.outcome}` }),
-              ...(r.doi && {
-                identifier: {
-                  "@type": "PropertyValue",
-                  propertyID: "DOI",
-                  value: r.doi,
-                },
-              }),
-            })),
-          ]
-        : undefined,
+    isBasedOn: { "@id": `${SITE_URL}/#dataset` },
+    subjectOf: subjectOf.length > 0 ? subjectOf : undefined,
+  };
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "FLoRA Replication Atlas",
+        item: `${SITE_URL}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Studies",
+        item: `${SITE_URL}/browse/`,
+      },
+      { "@type": "ListItem", position: 3, name: title, item: pageUrl },
+    ],
+  };
+
+  const jsonLd = JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [article, breadcrumb],
   });
 
-  const ogImageUrl = `${SITE_URL}/doi/${doi}/og.png`;
   return {
-    title: `${title} — FLoRA Replication Atlas`,
+    title: pageTitle,
     description,
-    keywords,
     pageUrl,
     jsonLd,
     authors,
-    ogImageUrl,
+    ogImageUrl: `${SITE_URL}/doi/${doi}/og.png`,
   };
+}
+
+function attemptLine(entry, atlasDois) {
+  const href = atlasHref(entry.doi, atlasDois);
+  const name = escHtml(cleanTitle(entry.title) || entry.doi || "Untitled attempt");
+  const label = href ? `<a href="${href}">${name}</a>` : name;
+  const by = escHtml(formatAuthors(entry.authors));
+  const year = entry.year ? ` (${escHtml(entry.year)})` : "";
+  const outcome = entry.outcome
+    ? ` Outcome recorded: ${escHtml(entry.outcome)}.`
+    : " No outcome recorded.";
+  const quote = entry.outcome_quote
+    ? ` <q>${escHtml(String(entry.outcome_quote).split("||")[0].trim().slice(0, 300))}</q>`
+    : "";
+  const paper = entry.doi
+    ? ` <a href="https://doi.org/${escHtml(entry.doi)}">View paper</a>`
+    : "";
+  return `<li><strong>${label}</strong>, ${by}${year}.${outcome}${quote}${paper}</li>`;
+}
+
+// Links each page on to the next few, so they form a crawlable ring.
+const RELATED_COUNT = 6;
+function relatedLinks(dois, index, papers) {
+  const out = [];
+  for (let k = 1; k <= RELATED_COUNT && k < dois.length; k++) {
+    const other = dois[(index + k) % dois.length];
+    const label = cleanTitle(papers[other]?.title) || other;
+    out.push(
+      `<li><a href="${SITE_URL}/doi/${escHtml(other)}/">${escHtml(label.length > 90 ? label.slice(0, 89) + "\u2026" : label)}</a></li>`,
+    );
+  }
+  return out.join("\n        ");
+}
+
+/** The crawlable copy of the record, for crawlers that never run the app. */
+function renderBody(paper, dois, index, papers, atlasDois) {
+  const doi = paper.doi;
+  const title = cleanTitle(paper.title) || doi;
+  const authors = Array.isArray(paper.authors) ? paper.authors : [];
+  const authorNames = authors
+    .map((a) => cleanAuthorName([a.given, a.family].filter(Boolean).join(" ")))
+    .filter(Boolean)
+    .join(", ");
+  const replications = paper.record?.replications || [];
+  const reproductions = paper.record?.reproductions || [];
+
+  const venue = [paper.journal, paper.year]
+    .filter(Boolean)
+    .map((x) => escHtml(String(x)))
+    .join(", ");
+
+  const parts = [];
+  if (replications.length > 0)
+    parts.push(
+      `${replications.length} ${replications.length === 1 ? "replication" : "replications"}`,
+    );
+  if (reproductions.length > 0)
+    parts.push(
+      `${reproductions.length} ${reproductions.length === 1 ? "reproduction" : "reproductions"}`,
+    );
+
+  const counts = outcomeCounts(paper);
+  const outcomeSentence =
+    counts.length > 0
+      ? ` Recorded outcomes: ${counts
+          .map(([b, n]) => `${n} ${b === "unrecorded" ? "with no outcome recorded" : b}`)
+          .join(", ")}.`
+      : "";
+  const summary =
+    parts.length > 0
+      ? `The atlas records ${parts.join(" and ")} of this study.${outcomeSentence}`
+      : "The atlas has no replication or reproduction of this study on record yet.";
+
+  const section = (heading, items) =>
+    items.length > 0
+      ? `<h3>${heading}</h3>
+        <ul>
+        ${items.map((r) => attemptLine(r, atlasDois)).join("\n        ")}
+        </ul>`
+      : "";
+
+  const noneNote =
+    parts.length === 0
+      ? `<p>An absent record is not evidence that the finding failed to replicate. It means no attempt has been indexed here yet. <a href="${SITE_URL}/">Search the atlas</a> for related work, or send in a replication we have missed.</p>`
+      : "";
+
+  return `<main class="ssg">
+        <p class="ssg-meta"><a href="${SITE_URL}/">FLoRA Replication Atlas</a> &rsaquo; <a href="${SITE_URL}/browse/">Browse</a></p>
+        <h1>${escHtml(title)}</h1>
+        ${authorNames ? `<p class="ssg-meta">${escHtml(authorNames)}</p>` : ""}
+        <p class="ssg-meta">${venue}${venue ? ". " : ""}DOI <a href="https://doi.org/${escHtml(doi)}">${escHtml(doi)}</a></p>
+
+        <h2>Has this study been replicated?</h2>
+        <p>${summary}</p>
+        ${section("Replications", replications)}
+        ${section("Reproductions", reproductions)}
+        ${noneNote}
+
+        <h2>Other studies in the atlas</h2>
+        <ul class="ssg-related">
+        ${relatedLinks(dois, index, papers)}
+        </ul>
+        <p><a href="${SITE_URL}/browse/outcome/failed/">Failed replications</a> &middot;
+        <a href="${SITE_URL}/browse/outcome/successful/">Successful replications</a> &middot;
+        <a href="${SITE_URL}/browse/">All browse pages</a></p>
+      </main>`;
 }
 
 function escSvg(str) {
@@ -368,8 +474,7 @@ async function generateOgImage(paper) {
 }
 
 function injectMeta(html, meta) {
-  const { title, description, keywords, pageUrl, jsonLd, authors, ogImageUrl } =
-    meta;
+  const { title, description, pageUrl, jsonLd, authors, ogImageUrl } = meta;
 
   html = html.replace(
     /<title>[^<]*<\/title>/,
@@ -385,11 +490,6 @@ function injectMeta(html, meta) {
     /(<meta name="description" content=")[^"]*(")/,
     `$1${escHtml(description)}$2`,
   );
-  html = html.replace(
-    /(<meta name="keywords" content=")[^"]*(")/,
-    `$1${escHtml(keywords)}$2`,
-  );
-
   html = html.replace(
     /(<meta property="og:title" content=")[^"]*(")/,
     `$1${escHtml(title)}$2`,
@@ -426,6 +526,14 @@ function injectMeta(html, meta) {
     `$1${escHtml(description)}$2`,
   );
 
+  // Swap the landing page's crawlable copy for this paper's own.
+  if (meta.body) {
+    html = html.replace(
+      /<!--ssg-start-->[\s\S]*?<!--ssg-end-->/,
+      `<!--ssg-start-->\n      ${meta.body}\n      <!--ssg-end-->`,
+    );
+  }
+
   // Replace the site-level JSON-LD with the per-article one
   html = html.replace(
     /<script type="application\/ld\+json">[\s\S]*?<\/script>/,
@@ -450,7 +558,22 @@ async function main() {
   const baseHtml = await readFile(join(DIST_DIR, "index.html"), "utf-8");
 
   console.log("Fetching DOI list...");
-  const dois = await fetchAllDois();
+  let dois = await fetchAllDois();
+
+  // A source URL in the DOI field would become a nested directory here.
+  const malformed = dois.filter((d) => !/^10\./.test(d));
+  if (malformed.length) {
+    console.warn(
+      `  Skipping ${malformed.length} record(s) whose DOI field is not a DOI: ${malformed.slice(0, 5).join(", ")}`,
+    );
+    dois = dois.filter((d) => /^10\./.test(d));
+  }
+
+  // Local smoke-testing hook: PRERENDER_LIMIT=3 npm run prerender-doi-pages
+  if (process.env.PRERENDER_LIMIT) {
+    dois = dois.slice(0, Number(process.env.PRERENDER_LIMIT));
+    console.log(`PRERENDER_LIMIT set, building ${dois.length} pages only.`);
+  }
   console.log(
     `Found ${dois.length} DOIs. Fetching paper data in batches of ${BATCH_SIZE}...`,
   );
@@ -459,28 +582,41 @@ async function main() {
   const fetched = Object.keys(papers).length;
   console.log(`Got data for ${fetched}/${dois.length} DOIs. Writing pages...`);
 
+  // Only link on to a study that actually has a page here.
+  const atlasDois = new Set(dois);
+
   let withMeta = 0;
   let withoutMeta = 0;
 
-  for (const doi of dois) {
+  for (let i = 0; i < dois.length; i++) {
+    const doi = dois[i];
     const paper = papers[doi];
     const outDir = join(DIST_DIR, "doi", doi);
     await mkdir(outDir, { recursive: true });
 
     if (paper) {
       withMeta++;
-      const meta = buildPageMeta(paper);
+      const meta = buildPageMeta(paper, atlasDois);
+      meta.body = renderBody(paper, dois, i, papers, atlasDois);
       const html = injectMeta(baseHtml, meta);
       await writeFile(join(outDir, "index.html"), html, "utf-8");
-      try {
-        const png = await generateOgImage(paper);
-        await writeFile(join(outDir, "og.png"), png);
-      } catch (e) {
-        console.warn(`  OG image failed for ${doi}: ${e.message}`);
+      // The slow half of the build; skip it when only the HTML is under test.
+      if (!process.env.PRERENDER_SKIP_OG) {
+        try {
+          const png = await generateOgImage(paper);
+          await writeFile(join(outDir, "og.png"), png);
+        } catch (e) {
+          console.warn(`  OG image failed for ${doi}: ${e.message}`);
+        }
       }
     } else {
+      // Drop the landing copy so a DOI URL never presents the home page's text.
       withoutMeta++;
-      await writeFile(join(outDir, "index.html"), baseHtml, "utf-8");
+      const fallback = baseHtml.replace(
+        /<!--ssg-start-->[\s\S]*?<!--ssg-end-->/,
+        `<!--ssg-start--><main class="ssg"><h1>${escHtml(doi)}</h1><p>This record is in the atlas but its metadata could not be loaded at build time. <a href="${SITE_URL}/">Search the atlas</a> or open <a href="https://doi.org/${escHtml(doi)}">https://doi.org/${escHtml(doi)}</a>.</p></main><!--ssg-end-->`,
+      );
+      await writeFile(join(outDir, "index.html"), fallback, "utf-8");
     }
 
     const written = withMeta + withoutMeta;
@@ -489,8 +625,21 @@ async function main() {
   }
 
   console.log(
-    `Done. ${withMeta} pages with meta + OG image, ${withoutMeta} with fallback HTML.`,
+    `Done. ${withMeta} pages with meta${process.env.PRERENDER_SKIP_OG ? "" : " + OG image"}, ${withoutMeta} with fallback HTML.`,
   );
+
+  console.log("Writing browse pages...");
+  const browseUrls = await generateBrowsePages(
+    DIST_DIR,
+    dois.map((d) => papers[d]).filter(Boolean),
+  );
+  // generate-sitemap.js reads this so the browse layer is in the sitemap too.
+  await writeFile(
+    join(DIST_DIR, "browse-index.json"),
+    JSON.stringify(browseUrls, null, 0),
+    "utf-8",
+  );
+  console.log(`Done. ${browseUrls.length} browse pages written.`);
 }
 
 main().catch((err) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { TopBar, type SearchMode } from "./components/layout/TopBar";
 import { StudyListPanel } from "./components/layout/StudyListPanel";
 import {
   WelcomeState,
-  exampleSearches,
+  ExampleSearchLinks,
 } from "./components/layout/WelcomeState";
 import { AdvancedSearchPanel } from "./components/layout/AdvancedSearchPanel";
 import { DetailView } from "./components/layout/DetailView";
@@ -815,29 +815,10 @@ function App() {
                         }
                       >
                         <div class="no-results-pane">
-                          <div class="welcome-examples">
-                            <div class="welcome-examples-label">
-                              Example searches
-                            </div>
-                            {exampleSearches.map((ex) => (
-                              <div
-                                class="welcome-doi"
-                                onClick={() => handleExampleClick(ex.query)}
-                              >
-                                <span>{ex.label}</span>
-                                <svg
-                                  width="14"
-                                  height="14"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  stroke-width="2"
-                                >
-                                  <polyline points="9,18 15,12 9,6" />
-                                </svg>
-                              </div>
-                            ))}
-                          </div>
+                          <ExampleSearchLinks
+                            label="Example searches"
+                            onExampleClick={handleExampleClick}
+                          />
                         </div>
                       </Show>
                     }
@@ -861,27 +842,11 @@ function App() {
                       <div class="no-results-sub">
                         Try a different search term or DOI
                       </div>
-                      <div class="welcome-examples" style="margin-top: 1.5rem">
-                        <div class="welcome-examples-label">Try an example</div>
-                        {exampleSearches.map((ex) => (
-                          <div
-                            class="welcome-doi"
-                            onClick={() => handleExampleClick(ex.query)}
-                          >
-                            <span>{ex.label}</span>
-                            <svg
-                              width="14"
-                              height="14"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-width="2"
-                            >
-                              <polyline points="9,18 15,12 9,6" />
-                            </svg>
-                          </div>
-                        ))}
-                      </div>
+                      <ExampleSearchLinks
+                        label="Try an example"
+                        onExampleClick={handleExampleClick}
+                        centered
+                      />
                     </div>
                   </Show>
                 }

--- a/src/components/layout/ReplicationItemCard.tsx
+++ b/src/components/layout/ReplicationItemCard.tsx
@@ -1,4 +1,5 @@
 import { createSignal, For } from "solid-js";
+import { A } from "@solidjs/router";
 import type { ReplicationItem } from "../../@types";
 import { authorYearLine, normalizeOutcome } from "../../utils/formatter";
 
@@ -78,7 +79,16 @@ export const ReplicationItemCard = (props: ReplicationItemCardProps) => {
           </For>
         </div>
         <div class="ri-body">
-          {props.item.title ? <div class="ri-title">{props.item.title}</div> : null}
+          {props.item.title ? (
+            <div class="ri-title">
+              {/* A linked study usually has its own atlas page; link to it. */}
+              {props.item.doi?.startsWith("10.") ? (
+                <A href={`/doi/${props.item.doi}/`}>{props.item.title}</A>
+              ) : (
+                props.item.title
+              )}
+            </div>
+          ) : null}
           {meta() ? <div class="ri-meta">{meta()}</div> : null}
           {props.item.doi ? (
             <a

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -248,7 +248,9 @@ export const TopBar = (props: TopBarProps) => {
             <div class="topbar-icon">
               <img
                 src={forrt}
-                alt="F"
+                alt="FORRT"
+                width="20"
+                height="20"
                 style={{ width: "20px", height: "20px" }}
               />
             </div>

--- a/src/components/layout/WelcomeState.tsx
+++ b/src/components/layout/WelcomeState.tsx
@@ -33,6 +33,65 @@ export const exampleSearches = [
   { label: "10.1037/0022-3514.54.5.768", query: "10.1037/0022-3514.54.5.768" },
 ];
 
+const ChevronRight = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    aria-hidden="true"
+  >
+    <polyline points="9,18 15,12 9,6" />
+  </svg>
+);
+
+/** Real hrefs, not buttons: a DOI goes to its atlas page, a phrase to search. */
+export const ExampleSearchLinks = (props: {
+  label: string;
+  onExampleClick: (query: string) => void;
+  centered?: boolean;
+}) => {
+  const base = import.meta.env.BASE_URL || "/";
+  return (
+    <div
+      class="welcome-examples"
+      style={
+        props.centered
+          ? "margin-top: 1.5rem; justify-content: center"
+          : undefined
+      }
+    >
+      <div class="welcome-examples-label">{props.label}</div>
+      <For each={exampleSearches}>
+        {(ex) => {
+          const isDoi = ex.query.startsWith("10.");
+          const href = isDoi
+            ? `${base}doi/${ex.query}/`
+            : `${base}?q=${encodeURIComponent(ex.query)}`;
+          return (
+            <a
+              class="welcome-doi"
+              href={href}
+              onClick={(e) => {
+                // Modified and middle clicks fall through to the href.
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0)
+                  return;
+                e.preventDefault();
+                props.onExampleClick(ex.query);
+              }}
+            >
+              <span>{ex.label}</span>
+              <ChevronRight />
+            </a>
+          );
+        }}
+      </For>
+    </div>
+  );
+};
+
 export const WelcomeState = (props: WelcomeStateProps) => {
   let inputRef: HTMLInputElement | undefined;
   const [alertMessage, setAlertMessage] = createSignal<string | null>(null);
@@ -279,27 +338,10 @@ export const WelcomeState = (props: WelcomeStateProps) => {
         </a>
       </div>
 
-      <div class="welcome-examples">
-        <div class="welcome-examples-label">Example searches</div>
-        {exampleSearches.map((ex) => (
-          <div
-            class="welcome-doi"
-            onClick={() => props.onExampleClick(ex.query)}
-          >
-            <span>{ex.label}</span>
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <polyline points="9,18 15,12 9,6" />
-            </svg>
-          </div>
-        ))}
-      </div>
+      <ExampleSearchLinks
+        label="Example searches"
+        onExampleClick={props.onExampleClick}
+      />
       <p class="welcome-footnote">
         Powered by FORRT's Library of Reproduction and Replication Attempts
         (FLoRA), the Replication Atlas covers {paperCount.toLocaleString()}+

--- a/src/components/pages/DoiPage.tsx
+++ b/src/components/pages/DoiPage.tsx
@@ -1,6 +1,14 @@
 import { createSignal, Show, onMount, onCleanup } from "solid-js";
 import { useParams, useNavigate } from "@solidjs/router";
-import type { DOIResults, OriginalPaper } from "../../@types";
+import type { DOIResults, OriginalPaper, ReplicationItem } from "../../@types";
+import {
+  SITE_URL,
+  atlasPath,
+  buildDescription,
+  buildTitle,
+  cleanAuthorName,
+  cleanTitle,
+} from "../../seo/pageMeta.js";
 import { fetchMultipleDOIInfo } from "../../api/backend";
 import { appName } from "../../configs";
 import { TopBar, type SearchMode } from "../layout/TopBar";
@@ -17,197 +25,151 @@ export const DoiPage = () => {
   const [isLoading, setIsLoading] = createSignal(true);
   const [hasData, setHasData] = createSignal(false);
 
-  // SEO: update document title and meta tags
+  // SEO: keep a soft navigation's head identical to what the prerenderer wrote.
   const updateMeta = (paper: OriginalPaper | null) => {
-    if (paper?.title) {
-      document.title = `${paper.title} — ${appName}`;
+    if (!paper?.title) {
+      document.title = `${doi()} — ${appName}`;
+      return;
+    }
 
-      const setMetaTag = (name: string, content: string, attr = "name") => {
-        let el = document.querySelector(
-          `meta[${attr}="${name}"]`,
-        ) as HTMLMetaElement | null;
-        if (!el) {
-          el = document.createElement("meta");
-          el.setAttribute(attr, name);
-          document.head.appendChild(el);
-        }
-        el.content = content;
-      };
-
-      const authors =
-        paper.authors?.map((a) => `${a.family}, ${a.given}`).join("; ") || "";
-      const authorLastNames =
-        paper.authors?.map((a) => a.family).filter(Boolean) || [];
-
-      const stats = paper.record?.stats;
-      const replications = paper.record?.replications || [];
-      const reproductions = paper.record?.reproductions || [];
-      const allOutcomes = [
-        ...replications.map((r) => r.outcome),
-        ...reproductions.map((r) => r.outcome),
-      ].filter(Boolean);
-      const uniqueOutcomes = [...new Set(allOutcomes)] as string[];
-      const nReplications = stats?.n_replications_total ?? 0;
-      const nReproductions = stats?.n_reproductions_total ?? 0;
-
-      const formatAuthors = (a: (typeof replications)[0]["authors"]) => {
-        if (!a?.length) return "unknown authors";
-        if (a.length === 1) return a[0].family;
-        if (a.length === 2) return `${a[0].family} & ${a[1].family}`;
-        return `${a[0].family} et al.`;
-      };
-
-      const replicationSentences = replications.map((r) => {
-        const by = formatAuthors(r.authors);
-        const outcome = r.outcome
-          ? `described as ${r.outcome}`
-          : "outcome not recorded";
-        return `"${paper.title}" has been replicated by ${by} (${r.year}), ${outcome}.`;
-      });
-
-      const reproductionSentences = reproductions.map((r) => {
-        const by = formatAuthors(r.authors);
-        const outcome = r.outcome
-          ? `described as ${r.outcome}`
-          : "outcome not recorded";
-        return `"${paper.title}" has been reproduced by ${by} (${r.year}), ${outcome}.`;
-      });
-
-      const replicationSummary =
-        replicationSentences.length > 0 || reproductionSentences.length > 0
-          ? [...replicationSentences, ...reproductionSentences].join(" ")
-          : "No replications or reproductions recorded yet.";
-
-      const description =
-        `"${paper.title}" by ${authors} (${paper.year}${paper.journal ? `, ${paper.journal}` : ""}). ` +
-        `${replicationSummary} Indexed in the FLoRA Replication Atlas (FORRT FLoRA database). DOI: ${paper.doi}`;
-
-      // Keywords: author names + title terms + journal + outcomes + standard SEO terms
-      const titleKeywords =
-        paper.title
-          ?.split(/\s+/)
-          .filter((w) => w.length > 4)
-          .slice(0, 6)
-          .map((w) => w.replace(/[^a-zA-Z0-9]/g, ""))
-          .filter(Boolean) || [];
-      const keywords = [
-        ...authorLastNames,
-        paper.journal,
-        String(paper.year),
-        ...uniqueOutcomes.map((o) => `${o} replication`),
-        ...titleKeywords,
-        "replication",
-        "reproducibility",
-        "open science",
-        "FLoRA",
-        "FReD",
-        "FORRT",
-        "replication crisis",
-        "has this study been replicated",
-      ]
-        .filter(Boolean)
-        .join(", ");
-
-      setMetaTag("description", description);
-      setMetaTag("keywords", keywords);
-      setMetaTag("og:title", paper.title, "property");
-      setMetaTag("og:description", description, "property");
-      setMetaTag("og:type", "article", "property");
-
-      // Always point at the trailing-slash URL: that is what GitHub Pages serves
-      // (the slash-less form 301s to it), so it must be the declared canonical.
-      const base = import.meta.env.BASE_URL || "/";
-      const canonicalUrl = `${window.location.origin}${base}doi/${doi()}/`;
-      setMetaTag("og:url", canonicalUrl, "property");
-
-      let canonicalLink = document.querySelector(
-        'link[rel="canonical"]',
-      ) as HTMLLinkElement | null;
-      if (!canonicalLink) {
-        canonicalLink = document.createElement("link");
-        canonicalLink.rel = "canonical";
-        document.head.appendChild(canonicalLink);
-      }
-      canonicalLink.href = canonicalUrl;
-
-      // Per-author OG tags for LLM and social parsers
-      const existingAuthorMetas = document.querySelectorAll(
-        'meta[property="article:author"]',
-      );
-      existingAuthorMetas.forEach((el) => el.remove());
-      paper.authors?.forEach((a) => {
-        const el = document.createElement("meta");
-        el.setAttribute("property", "article:author");
-        el.content = `${a.given} ${a.family}`;
+    const setMetaTag = (name: string, content: string, attr = "name") => {
+      let el = document.querySelector(
+        `meta[${attr}="${name}"]`,
+      ) as HTMLMetaElement | null;
+      if (!el) {
+        el = document.createElement("meta");
+        el.setAttribute(attr, name);
         document.head.appendChild(el);
-      });
-
-      // Schema.org structured data for search engines and LLMs
-      let script = document.getElementById(
-        "doi-jsonld",
-      ) as HTMLScriptElement | null;
-      if (!script) {
-        script = document.createElement("script");
-        script.id = "doi-jsonld";
-        script.type = "application/ld+json";
-        document.head.appendChild(script);
       }
-      script.textContent = JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "ScholarlyArticle",
-        name: paper.title,
-        author: paper.authors?.map((a) => ({
-          "@type": "Person",
-          givenName: a.given,
-          familyName: a.family,
-        })),
-        datePublished: String(paper.year),
-        isPartOf: paper.journal
-          ? { "@type": "Periodical", name: paper.journal }
-          : undefined,
+      el.content = content;
+    };
+
+    const replications = paper.record?.replications || [];
+    const reproductions = paper.record?.reproductions || [];
+    const title = cleanTitle(paper.title) || paper.doi;
+    const description = buildDescription(paper);
+
+    document.title = buildTitle(paper);
+    setMetaTag("description", description);
+    setMetaTag("og:title", document.title, "property");
+    setMetaTag("og:description", description, "property");
+    setMetaTag("og:type", "article", "property");
+
+    // Always point at the trailing-slash URL: that is what GitHub Pages serves
+    // (the slash-less form 301s to it), so it must be the declared canonical.
+    const base = import.meta.env.BASE_URL || "/";
+    const canonicalUrl = `${window.location.origin}${base}doi/${doi()}/`;
+    setMetaTag("og:url", canonicalUrl, "property");
+    setMetaTag("og:image", `${canonicalUrl}og.png`, "property");
+    setMetaTag("twitter:image", `${canonicalUrl}og.png`);
+
+    let canonicalLink = document.querySelector(
+      'link[rel="canonical"]',
+    ) as HTMLLinkElement | null;
+    if (!canonicalLink) {
+      canonicalLink = document.createElement("link");
+      canonicalLink.rel = "canonical";
+      document.head.appendChild(canonicalLink);
+    }
+    canonicalLink.href = canonicalUrl;
+
+    // Per-author OG tags for LLM and social parsers
+    document
+      .querySelectorAll('meta[property="article:author"]')
+      .forEach((el) => el.remove());
+    paper.authors?.forEach((a) => {
+      const el = document.createElement("meta");
+      el.setAttribute("property", "article:author");
+      el.content = cleanAuthorName(`${a.given} ${a.family}`);
+      document.head.appendChild(el);
+    });
+
+    // Schema.org structured data for search engines and LLMs
+    let script = document.getElementById(
+      "doi-jsonld",
+    ) as HTMLScriptElement | null;
+    if (!script) {
+      script = document.createElement("script");
+      script.id = "doi-jsonld";
+      script.type = "application/ld+json";
+      document.head.appendChild(script);
+    }
+
+    const attempt = (r: ReplicationItem, kind: string) => ({
+      "@type": "ScholarlyArticle",
+      name: cleanTitle(r.title) || r.doi,
+      additionalType: `${SITE_URL}/#${kind}`,
+      ...(r.doi && {
+        url: atlasPath(r.doi),
+        mainEntityOfPage: atlasPath(r.doi),
         identifier: {
           "@type": "PropertyValue",
           propertyID: "DOI",
-          value: paper.doi,
+          value: r.doi,
         },
-        url: `https://doi.org/${paper.doi}`,
-        description,
-        keywords: keywords,
-        subjectOf:
-          nReplications > 0 || nReproductions > 0
-            ? [
-                ...replications.map((r) => ({
-                  "@type": "ScholarlyArticle",
-                  name: r.title,
-                  additionalType: "ReplicationStudy",
-                  ...(r.outcome && { description: `Outcome: ${r.outcome}` }),
-                  ...(r.doi && {
-                    identifier: {
-                      "@type": "PropertyValue",
-                      propertyID: "DOI",
-                      value: r.doi,
-                    },
-                  }),
-                })),
-                ...reproductions.map((r) => ({
-                  "@type": "ScholarlyArticle",
-                  name: r.title,
-                  additionalType: "ReproductionStudy",
-                  ...(r.outcome && { description: `Outcome: ${r.outcome}` }),
-                  ...(r.doi && {
-                    identifier: {
-                      "@type": "PropertyValue",
-                      propertyID: "DOI",
-                      value: r.doi,
-                    },
-                  }),
-                })),
-              ]
+        sameAs: `https://doi.org/${r.doi}`,
+      }),
+      ...(r.outcome && { description: `Outcome: ${r.outcome}` }),
+      ...(r.year && { datePublished: String(r.year) }),
+    });
+
+    const subjectOf = [
+      ...replications.map((r) => attempt(r, "ReplicationStudy")),
+      ...reproductions.map((r) => attempt(r, "ReproductionStudy")),
+    ];
+
+    script.textContent = JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "ScholarlyArticle",
+          "@id": `${canonicalUrl}#article`,
+          mainEntityOfPage: canonicalUrl,
+          name: title,
+          headline: title,
+          author: paper.authors
+            ?.map((a) => ({
+              "@type": "Person",
+              givenName: cleanAuthorName(a.given) || undefined,
+              familyName: cleanAuthorName(a.family) || undefined,
+              name: cleanAuthorName([a.given, a.family].filter(Boolean).join(" ")),
+            }))
+            .filter((a) => a.name),
+          datePublished: String(paper.year),
+          isPartOf: paper.journal
+            ? { "@type": "Periodical", name: paper.journal }
             : undefined,
-      });
-    } else {
-      document.title = `${doi()} — ${appName}`;
-    }
+          identifier: {
+            "@type": "PropertyValue",
+            propertyID: "DOI",
+            value: paper.doi,
+          },
+          url: canonicalUrl,
+          sameAs: `https://doi.org/${paper.doi}`,
+          description,
+          isBasedOn: { "@id": `${SITE_URL}/#dataset` },
+          subjectOf: subjectOf.length > 0 ? subjectOf : undefined,
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: appName,
+              item: `${SITE_URL}/`,
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Studies",
+              item: `${SITE_URL}/browse/`,
+            },
+            { "@type": "ListItem", position: 3, name: title, item: canonicalUrl },
+          ],
+        },
+      ],
+    });
   };
 
   onCleanup(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -973,6 +973,7 @@ a.welcome-import-card {
   cursor: pointer;
   transition: all var(--transition-fast);
   font-family: var(--font-body);
+  text-decoration: none;
 }
 .welcome-doi:hover {
   border-color: var(--primary);
@@ -1480,6 +1481,14 @@ a.welcome-import-card {
   line-height: 1.4;
   margin-bottom: 0.2rem;
   color: var(--text);
+}
+.ri-title a {
+  color: inherit;
+  text-decoration: none;
+}
+.ri-title a:hover {
+  color: var(--primary);
+  text-decoration: underline;
 }
 .ri-meta {
   font-size: 12px;
@@ -4422,3 +4431,31 @@ a.welcome-import-card {
     justify-content: flex-end;
   }
 }
+
+/* The crawlable copy of the page that ships inside #root. Scripted clients
+   replace it before paint; this styling is for the ones that never do. */
+.ssg {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+  font-family: "Source Sans 3", system-ui, sans-serif;
+  color: var(--neutral);
+  line-height: 1.6;
+}
+.ssg h1,
+.ssg h2,
+.ssg h3 {
+  font-family: Domine, Georgia, serif;
+  color: var(--primary-dark);
+  line-height: 1.25;
+}
+.ssg h1 { font-size: 1.9rem; margin: 0 0 0.75rem; }
+.ssg h2 { font-size: 1.3rem; margin: 2rem 0 0.5rem; }
+.ssg h3 { font-size: 1.05rem; margin: 1.5rem 0 0.4rem; }
+.ssg a { color: var(--primary); text-decoration: underline; }
+.ssg ul { padding-left: 1.1rem; }
+.ssg li { margin-bottom: 0.6rem; }
+.ssg dt { font-weight: 600; margin-top: 0.9rem; }
+.ssg dd { margin: 0.15rem 0 0 0; }
+.ssg .ssg-meta { color: #5f5f5f; margin: 0.2rem 0; }
+.ssg q { color: #444; font-style: italic; }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,9 @@ const base = import.meta.env.BASE_URL
 
 const root = document.getElementById('root')
 
+// #root ships a crawlable static copy; Solid appends rather than replaces it.
+if (root) root.textContent = ''
+
 render(
   () => (
     <Router base={base.endsWith('/') ? base.slice(0, -1) : base}>

--- a/src/seo/pageMeta.js
+++ b/src/seo/pageMeta.js
@@ -1,0 +1,172 @@
+/**
+ * Title and description templates for atlas detail pages.
+ *
+ * Plain JS with JSDoc types so the Node prerender script and the Solid client
+ * can share one implementation: whatever the build writes into the static head
+ * is exactly what the client rewrites on a soft navigation.
+ */
+
+export const SITE_URL = "https://forrt.org/flora-replication-atlas";
+
+const TITLE_BUDGET = 65;
+const DESCRIPTION_BUDGET = 158;
+const MIN_TITLE_STUB = 25;
+const MAX_TITLE_STUB = 45;
+
+/* Artefacts that reach the SERP straight out of the source spreadsheet:
+   filename-shaped titles, bracketed coder tokens, and the trailing record hash. */
+const SOURCE_ARTEFACTS = [
+  /\s*-\s*[A-Za-z0-9]{4}$/, // trailing record hash: "… - k97z"
+  /\s*\[[A-Z][A-Z _-]{2,}\]\s*/g, // coder tokens: "[SCORE]"
+  /^\s*\[[^\]]{1,12}\]\s*/, // leading record number: "[94] Data Replicada …"
+];
+
+/** @param {string} raw */
+export function cleanTitle(raw) {
+  let t = String(raw ?? "").trim();
+  if (!t) return "";
+  // Underscore-joined runs are filenames the source data kept, not prose.
+  t = t.replace(/\S*_\S*/g, (token) => token.replace(/_+/g, " "));
+  t = t.replace(SOURCE_ARTEFACTS[1], " ");
+  t = t.replace(SOURCE_ARTEFACTS[2], "");
+  t = t.replace(SOURCE_ARTEFACTS[0], "");
+  return t.replace(/\s+/g, " ").replace(/[\s.,;:-]+$/, "").trim();
+}
+
+/** Truncate at a word boundary, appending an ellipsis only when text was cut. */
+export function truncateWords(text, max) {
+  const t = String(text ?? "").trim();
+  if (t.length <= max) return t;
+  const cut = t.slice(0, max - 1);
+  const lastSpace = cut.lastIndexOf(" ");
+  const stem = (lastSpace > max * 0.5 ? cut.slice(0, lastSpace) : cut).replace(
+    /[\s.,;:-]+$/,
+    "",
+  );
+  return `${stem}…`;
+}
+
+/** @param {string} [outcome] */
+export function outcomeBucket(outcome) {
+  const o = String(outcome ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+  if (!o) return "unrecorded";
+  if (o === "successful" || o === "success") return "successful";
+  if (o === "failed" || o === "failure") return "failed";
+  if (o === "mixed") return "mixed";
+  if (o === "partial") return "partial";
+  if (o.startsWith("computationally successful") && /,\s*robust$/.test(o))
+    return "successful";
+  if (o.startsWith("computational issues")) return "failed";
+  return "mixed";
+}
+
+function attempts(paper) {
+  const record = paper?.record || {};
+  return [
+    ...(Array.isArray(record.replications) ? record.replications : []),
+    ...(Array.isArray(record.reproductions) ? record.reproductions : []),
+  ];
+}
+
+/** Counts per bucket, highest first, for the pages' one distinguishing fact. */
+export function outcomeCounts(paper) {
+  const counts = new Map();
+  for (const a of attempts(paper)) {
+    const b = outcomeBucket(a?.outcome);
+    counts.set(b, (counts.get(b) || 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+/** Drops coder tokens the source data carries in the author field, e.g. "[SCORE]". */
+export function cleanAuthorName(name) {
+  return String(name ?? "")
+    .replace(/\[[^\]]*\]/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/^[\s,;.]+|[\s,;]+$/g, "")
+    .trim();
+}
+
+/** Short surname form: "Nuttin", "Ziano & Feldman", "Ziano et al." */
+export function shortAuthors(authors) {
+  const names = (Array.isArray(authors) ? authors : [])
+    .map((a) => cleanAuthorName(a?.family || a?.given || ""))
+    .filter(Boolean);
+  if (!names.length) return "";
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} & ${names[1]}`;
+  return `${names[0]} et al.`;
+}
+
+/**
+ * The outcome half of the title: front-loaded, short enough that it survives
+ * SERP truncation, and never omitted even when the study title has to give way.
+ */
+function titleOutcomePhrase(paper) {
+  const counts = outcomeCounts(paper);
+  const total = counts.reduce((n, [, c]) => n + c, 0);
+  if (total === 0) return "no replications recorded";
+
+  const named = counts.filter(([b]) => b !== "unrecorded");
+  const word = named.length === 1 ? named[0][0] : "mixed results";
+  const label = named.length === 0 ? "outcome not recorded" : word;
+
+  if (total === 1) return `replicated: ${label}`;
+  return `${total} replications: ${label}`;
+}
+
+/** @returns {string} the `<title>` for a detail page. */
+export function buildTitle(paper) {
+  const phrase = titleOutcomePhrase(paper);
+  const clean = cleanTitle(paper?.title) || paper?.doi || "Study";
+  const budget = TITLE_BUDGET - phrase.length - 3;
+  const stub = truncateWords(
+    clean,
+    Math.max(MIN_TITLE_STUB, Math.min(MAX_TITLE_STUB, budget)),
+  );
+  return `${stub} — ${phrase}`;
+}
+
+function descriptionOutcomeSentence(paper) {
+  const counts = outcomeCounts(paper);
+  const total = counts.reduce((n, [, c]) => n + c, 0);
+  if (total === 0)
+    return "No replication or reproduction attempt is recorded in the FLoRA Replication Atlas.";
+
+  const parts = counts.map(([bucket, n]) =>
+    bucket === "unrecorded" ? `${n} without a recorded outcome` : `${n} ${bucket}`,
+  );
+  const word = total === 1 ? "attempt" : "attempts";
+  const summary =
+    counts.length === 1 && counts[0][0] !== "unrecorded"
+      ? counts[0][0]
+      : parts.join(", ");
+  return `${total} replication ${word} on record: ${summary}.`;
+}
+
+/** @returns {string} the meta description for a detail page, ≤158 characters. */
+export function buildDescription(paper) {
+  const sentence = descriptionOutcomeSentence(paper);
+  const byline = [
+    shortAuthors(paper?.authors),
+    paper?.year ? `(${paper.year}${paper?.journal ? `, ${truncateWords(paper.journal, 40)}` : ""})` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const tail = byline ? `${byline}. ${sentence}` : sentence;
+  const clean = cleanTitle(paper?.title);
+  const room = DESCRIPTION_BUDGET - tail.length - 3;
+  if (clean && room >= MIN_TITLE_STUB)
+    return `${truncateWords(clean, room)} — ${tail}`;
+  return tail;
+}
+
+/** Site-relative path of the atlas page for a DOI, or null when it has none. */
+export function atlasPath(doi) {
+  if (!doi || !/^10\./.test(String(doi))) return null;
+  return `${SITE_URL}/doi/${doi}/`;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,6 +11,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "allowJs": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     solidPlugin(),
+    {
+      // `define` only reaches JS; the static copy in index.html needs its own pass.
+      name: 'paper-count-html',
+      transformIndexHtml(html: string) {
+        return html.replaceAll(
+          '__PAPER_COUNT__',
+          readPaperCount().toLocaleString('en-US'),
+        );
+      },
+    },
   ],
   server: {
     port: 3000,


### PR DESCRIPTION
Add prerendering and static browse pages plus shared SEO templates. New scripts: prerender-doi-pages and browse-pages (write crawlable /doi/* pages, OG images, and browse HTML); generate-sitemap now includes browse URLs and filters malformed DOIs. Introduce src/seo/pageMeta.js for shared title/description/JSON-LD logic; update index.html and client head handling (index.tsx) to ship a crawlable SSG snippet. Minor UI/linking tweaks, CSS for SSG, Vite plugin to inject paper count, and build script/tsconfig adjustments.