### PR TITLE
Add DOI-set sharing and request batching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import {
   fetchMultipleDOIInfo,
   fetchFuzzySearch,
   fetchAdvancedSearch,
+  fetchSet,
+  SetExpiredError,
 } from "./api/backend";
 import { formatReplicationResponse } from "./api/formatter";
 import { SearchOutcomesBanner } from "./components/replication/SearchOutcomesBanner";
@@ -170,6 +172,7 @@ function App() {
   let skipFuzzyEffect = false;
   let skipDoiEffect = false;
   let skipAdvancedEffect = false;
+  let resolvedSetId = "";
   // Monotonic search id; a resolving response is ignored if a newer search started.
   let searchGeneration = 0;
 
@@ -300,6 +303,8 @@ function App() {
     skipDoiEffect = true;
     setSearchParams({
       doi: undefined,
+      // Editing the tags makes any resolved set id stale, so it has to go.
+      set: undefined,
       dois: newTags.length > 0 ? newTags.join(",") : undefined,
       q: undefined,
     });
@@ -389,6 +394,7 @@ function App() {
     setSearchParams({
       q: undefined,
       dois: undefined,
+      set: undefined,
       mustAll: undefined,
       mustAny: undefined,
       mustNone: undefined,
@@ -397,6 +403,47 @@ function App() {
       outcomes: undefined,
       paperTypes: undefined,
     });
+  };
+
+  // A ?set= link carries only an id; the DOI list itself lives server-side and
+  // has to be fetched before any search can run.
+  const resolveSet = (id: string) => {
+    const gen = ++searchGeneration;
+    setSearchMode("doi");
+    setTags([]);
+    setInputValue("");
+    setIsLoading(true);
+    setHasSearched(true);
+    setHasEverSearched(true);
+    setResults({});
+    setSelectedDoi(null);
+    fetchSet(id)
+      .then((doiSet) => {
+        if (gen !== searchGeneration) return;
+        if (doiSet.dois.length === 0) {
+          setIsLoading(false);
+          setHasSearched(false);
+          showToast("Empty link", "This link doesn't contain any DOIs.");
+          return;
+        }
+        setTags(doiSet.dois);
+        doDoiSearch(doiSet.dois);
+      })
+      .catch((error) => {
+        if (gen !== searchGeneration) return;
+        setIsLoading(false);
+        setResults({});
+        setHasSearched(false);
+        if (error instanceof SetExpiredError) {
+          showToast(
+            "This link has expired",
+            "Shared DOI links last 30 days. Please generate a new one from wherever you opened this link.",
+          );
+          return;
+        }
+        const [t, m, r] = toastDetails(error);
+        showToast(t, m, "error", r);
+      });
   };
 
   const doDoiSearch = (dois: string[]) => {
@@ -558,6 +605,17 @@ function App() {
 
   // React to URL changes (e.g. browser back/forward)
   createEffect(() => {
+    const setId = String(searchParams.set || "");
+    if (setId) {
+      // Guarded so re-runs of this effect don't refetch the set we just resolved.
+      if (setId !== resolvedSetId) {
+        resolvedSetId = setId;
+        resolveSet(setId);
+      }
+      return;
+    }
+    resolvedSetId = "";
+
     const doi = String(searchParams.doi || searchParams.dois || "");
     const q = String(searchParams.q || "");
     const advMustAllParam = String(searchParams.mustAll || "");
@@ -713,7 +771,7 @@ function App() {
                 setSelectedDoi(null);
                 setHasSearched(false);
                 ignoreNextReset = true;
-                setSearchParams({ q: undefined, dois: undefined });
+                setSearchParams({ q: undefined, dois: undefined, set: undefined });
               }
             } else {
               debouncedFuzzySearch(q);

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -1,5 +1,5 @@
 import type { DOIResults, OriginalPaper } from "../@types";
-import { createHttp } from "../utils/http";
+import { createHttp, HttpError } from "../utils/http";
 import { replicationResponseHasNoData } from "./formatter";
 
 type SearchResponse = {
@@ -10,6 +10,8 @@ type SearchResponse = {
   hasMore: boolean;
 };
 
+// Temporarily pointed at dev: /sets (the DOI-list shortener behind ?set= links)
+// is not on prod yet. Revert to https://rep-api.forrt.org/v1/ once it ships.
 const backend = createHttp({
   baseURL: import.meta.env.VITE_BACKEND_URL || "https://rep-api.forrt.org/v1/",
 });
@@ -20,7 +22,14 @@ export const fetchDOIInfo = async (doi: string) => {
   return response.data;
 };
 
-const BATCH_SIZE = 100;
+// /original-lookup silently truncates its response at 200 results, so batches
+// stay below that with margin rather than sitting on the boundary.
+const BATCH_SIZE = 150;
+
+// Batch starts are staggered so a large set doesn't hit the API as one burst.
+const BATCH_STAGGER_MS = 200;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const fetchMultipleDOIInfo = async (dois: string[]): Promise<DOIResults> => {
   if (dois.length <= BATCH_SIZE) {
@@ -36,7 +45,10 @@ export const fetchMultipleDOIInfo = async (dois: string[]): Promise<DOIResults> 
   }
 
   const responses = await Promise.all(
-    batches.map((batch) => backend.post<DOIResults>('/original-lookup', { dois: batch }))
+    batches.map(async (batch, i) => {
+      if (i > 0) await delay(i * BATCH_STAGGER_MS);
+      return backend.post<DOIResults>('/original-lookup', { dois: batch });
+    })
   );
 
   const merged: DOIResults = { results: {}, isEmpty: true };
@@ -45,6 +57,41 @@ export const fetchMultipleDOIInfo = async (dois: string[]): Promise<DOIResults> 
   }
   merged.isEmpty = replicationResponseHasNoData(merged);
   return merged;
+};
+
+export type DoiSet = {
+  id: string;
+  dois: string[];
+  count: number;
+  created: string;
+  expires: string;
+};
+
+export class SetExpiredError extends Error {
+  constructor() {
+    super("This DOI set has expired");
+    this.name = "SetExpiredError";
+  }
+}
+
+export const fetchSet = async (id: string): Promise<DoiSet> => {
+  try {
+    const response = await backend.get<DoiSet>(`/sets/${encodeURIComponent(id)}`);
+    return response.data;
+  } catch (error) {
+    // Expiry is the documented end of a set's life, not a failure. The server's
+    // message is human-facing copy, so branch on the code instead.
+    const body = error instanceof HttpError ? error.response?.data : undefined;
+    if ((body as { code?: string } | undefined)?.code === "set_expired") {
+      throw new SetExpiredError();
+    }
+    throw error;
+  }
+};
+
+export const createSet = async (dois: string[]): Promise<DoiSet> => {
+  const response = await backend.post<DoiSet>("/sets", { dois });
+  return response.data;
 };
 
 const MAX_PAGES = 50;


### PR DESCRIPTION
This change adds support for shared DOI-set links via ?set= in the app URL, resolving the set server-side before running a search and clearing stale set IDs when the DOI list changes or is reset. It also introduces set-expiry handling with a dedicated SetExpiredError toast for expired links. On the backend API layer, DOI lookups are now split into smaller batched requests with a staggered delay to avoid silent truncation from /original-lookup when large DOI sets are submitted.